### PR TITLE
removes turbopack

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,7 +5,6 @@ const nextConfig: NextConfig = {
   images: {
     domains: ['metagame.games'],
   },
-  // Handle import.meta.env
   webpack: (config) => {
     config.resolve.alias = {
       ...config.resolve.alias,

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack",
-    "build": "next build --turbopack",
+    "dev": "next dev",
+    "build": "next build",
     "start": "next start",
     "lint": "next lint"
   },


### PR DESCRIPTION
Since we probably don't benefit from using turbopack I'm blindly listening to the warnings that say it's technically not produciton ready and having us fall back to using webpack for all build contexts