### PR TITLE
Fixes port numbers and playwright config

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -22,9 +22,15 @@ jobs:
         
     - name: Install dependencies
       run: pnpm install
-      
+
+    - name: Cache Playwright browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ runner.os }}-${{ hashFiles('**/pnpm-lock.yaml') }}
+
     - name: Install Playwright Browsers
-      run: pnpm exec playwright install --with-deps
+      run: pnpm exec playwright install
       
     - name: Run Playwright tests
       run: pnpm exec playwright test

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,7 +29,7 @@ jobs:
     - name: Run Playwright tests
       run: pnpm exec playwright test
       env:
-        PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.PUBLIC_STRIPE_PUBLISHABLE_KEY }}
+        NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}
       
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Then run the site with:
 pnpm dev
 ```
 
-The site should now be running at `http://localhost:4321`
+The site should now be running at `http://localhost:3000`
 
 ### Requirements
 - Node.js 18 or later

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: 'http://localhost:4321',
+    baseURL: 'http://localhost:3000',
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
     trace: 'on-first-retry',
     /* Screenshot on failure */
@@ -56,7 +56,7 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     command: 'pnpm dev',
-    url: 'http://localhost:4321',
+    url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120 * 1000,
   },


### PR DESCRIPTION
After the Next.js migration, the app runs on port 3000 by default rather than 4321. This updates the README to reference the right port, and more importantly the playwright config to listen to/direct requests to the correct port

Additionally, this fixes the name of the stripe env var that playwright acceses to be the new NEXT_PUBLIC one

Fixes https://github.com/tradingbootcamp/metagame/issues/28