### PR TITLE
adds supabase vars to playwright yml

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -36,6 +36,8 @@ jobs:
       run: pnpm exec playwright test
       env:
         NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY }}
+        NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+        NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
       
     - uses: actions/upload-artifact@v4
       if: ${{ !cancelled() }}


### PR DESCRIPTION
Playwright tests were failing because they didnt specify the secrets for supabase vars