### PR TITLE
minor warning fix on viewport export on layout.tsx

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Jura } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
 import "./globals.css";
@@ -50,10 +50,11 @@ export const metadata: Metadata = {
   icons: {
     icon: "/logo.svg",
   },
-  viewport: {
-    width: "device-width",
-    initialScale: 1,
-  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Little warning was popping up about some stupid metadata stuff on pnpm dev launch, this fixes it per  https://nextjs.org/docs/app/api-reference/functions/generate-viewport