### PR TITLE
reworks contribute page

### DIFF
--- a/components/ContributeContent.tsx
+++ b/components/ContributeContent.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import React, { useEffect } from 'react';
+import Image from 'next/image';
 import { Button } from './Button';
 import { SOCIAL_LINKS } from '../config';
 
@@ -30,21 +31,15 @@ export default function ContributeContent() {
 
   return (
     <div className="">
-      <section
-        className="hero prose-xl h-[50vh] flex flex-col items-center justify-center py-24 px-6 md:px-12 bg-cover bg-center bg-no-repeat"
-        id="hero"
-        style={{
-          backgroundImage: `
-            linear-gradient(
-              0deg,
-              rgb(11, 11, 17) 0%,
-              rgba(11, 11, 17, 0.4) 40%,
-              transparent 100%
-            ),
-            url("/game_pieces_2_cropped.jpg")`
-        }}
-      >
-        <div className="flex flex-col items-center justify-center"></div>
+      <section className="relative h-[30vh] flex flex-col items-center justify-center" id="hero">
+        <Image
+          src="/game_pieces_2_cropped.jpg"
+          alt="Game pieces"
+          fill
+          className="object-cover"
+          priority
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-dark-500 to-transparent" />
       </section>
 
       <div className="container mx-auto">


### PR DESCRIPTION
Current contribute page has way too big a header image. This restyles it to take up less vertical space, and replaces the vonfusing `<section>` with `backgroundImage` style tag to a hopefully simpler `<Image/>` tag and gradient opacity div overlay

## BEFORE
<img width="389" height="840" alt="image" src="https://github.com/user-attachments/assets/47a253dd-d3df-4304-ab4f-e8790070a064" />
<img width="1205" height="1095" alt="image" src="https://github.com/user-attachments/assets/3aed78d1-8e99-4778-b79b-68b3675a12e3" />

## UPDATED
<img width="373" height="766" alt="image" src="https://github.com/user-attachments/assets/1275db1f-d764-4fd1-bae5-f233ccdc69eb" />
<img width="1211" height="979" alt="image" src="https://github.com/user-attachments/assets/af4cab74-8aa6-465d-b44e-0961c2c5501d" />


