### PR TITLE
Brian/hydration fixes

### DIFF
--- a/components/sections/home/GetInvolved.tsx
+++ b/components/sections/home/GetInvolved.tsx
@@ -28,7 +28,7 @@ export default function GetInvolved() {
             <h2 className="mb-8 text-2xl font-bold text-secondary-200">
               Run something
             </h2>
-            <p className="mb-4 font-semibold">
+            <div className="mb-4 font-semibold">
               We will provide the venue, the resources, and the very eager audience, and you can run whatever experimental game concept you&apos;ve been toying with.
               <br />  
               <br />
@@ -41,7 +41,7 @@ export default function GetInvolved() {
                 <Button link="/contribute">
                   Dooooo it
                 </Button>
-            </p>
+            </div>
           </div>
         </div>
       </section>

--- a/components/sections/home/Speakers.tsx
+++ b/components/sections/home/Speakers.tsx
@@ -51,7 +51,7 @@ export default function Speakers({ speakers }: SpeakersProps) {
           <div className="flex flex-wrap justify-center gap-2 sm:gap-4 md:gap-6 max-w-8xl mx-auto">
             {speakers.map((speaker) => (
               <SpeakerCard
-                key={speaker.id}
+                key={speaker.name}
                 name={speaker.name}
                 image={speaker.image}
                 gameName={speaker.gameName}


### PR DESCRIPTION
Fixes a couple errors that were giving us Next error warnings in dev

-<p> tag on GetInvolved had a nested button witha div tag which is improper html; replaced with div
-Speaker card mapping has ids that are just numbers hard coded onto MD files, and we had some duplicate keys (two things had id set to 5); until we presumably move the speaker data to a supabase implementation, I made the react mapping key the name instead