### PR TITLE
adds prettier and its tailwind plugin

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "tabWidth": 2,
-  "useTabs": false
+  "useTabs": false,
+  "plugins": ["prettier-plugin-tailwindcss"]
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,7 +19,15 @@ export const metadata: Metadata = {
     template: "%s | METAGAME 2025",
   },
   description: "A conference for game design, strategy, narrative, and play",
-  keywords: ["game design", "conference", "strategy", "narrative", "play", "metagame", "2025"],
+  keywords: [
+    "game design",
+    "conference",
+    "strategy",
+    "narrative",
+    "play",
+    "metagame",
+    "2025",
+  ],
   authors: [{ name: "Arbor Team" }],
   creator: "Arbor",
   publisher: "Arbor",
@@ -63,14 +71,18 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className="bg-bg-primary text-text-primary" data-theme="synthwave">
+    <html
+      lang="en"
+      className="bg-bg-primary text-text-primary"
+      data-theme="synthwave"
+    >
       <body
-        className={`${jura.variable} font-sans antialiased relative overflow-x-hidden flex flex-col min-h-screen`}
+        className={`${jura.variable} relative flex min-h-screen flex-col overflow-x-hidden font-sans antialiased`}
       >
         <QueryProvider>
           <KbarApp>
             <Nav />
-            <div className="relative overflow-x-hidden flex-grow pt-[72px]">
+            <div className="relative flex-grow overflow-x-hidden pt-[72px]">
               {children}
             </div>
             <Footer />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,18 +29,21 @@ export default function Home() {
           <div id="set-animation">
             <SetAnimation />
           </div>
-          <section className="mb-8 mt-4" id="tickets">
+          <section className="mt-4 mb-8" id="tickets">
             <div className="container mx-auto flex flex-col items-center">
               <div className="mb-8">
-                <h2 className="text-3xl font-bold text-center">
+                <h2 className="text-center text-3xl font-bold">
                   Grab a ticket!
                 </h2>
-                <span className="text-lg text-gray-500 text-center ">Info coming soon about scholarships and discount ticket availability!</span>
+                <span className="text-center text-lg text-gray-500">
+                  Info coming soon about scholarships and discount ticket
+                  availability!
+                </span>
               </div>
-              <div className="grid grid-cols-1 gap-8 md:grid-cols-3 pb-20">
-                <TicketCard ticketTypeId="npc"/>
-                <TicketCard ticketTypeId="player"/>
-                <TicketCard ticketTypeId="supporter"/>
+              <div className="grid grid-cols-1 gap-8 pb-20 md:grid-cols-3">
+                <TicketCard ticketTypeId="npc" />
+                <TicketCard ticketTypeId="player" />
+                <TicketCard ticketTypeId="supporter" />
               </div>
             </div>
           </section>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
     "start": "next start",
     "lint": "next lint",
     "test": "playwright test",
+    "format": "prettier --write",
+    "fmt": "pnpm format",
+    "format:check": "prettier --check",
+    "fmt:check": "pnpm format:check",
     "types:supabase": "npx supabase gen types typescript --project-id fkarmpoupazxnshofaeg --schema public > types/database/supabase.types.ts"
   },
   "dependencies": {
@@ -55,6 +59,8 @@
     "eslint": "^9",
     "eslint-config-next": "15.3.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "prettier": "^3.6.2",
+    "prettier-plugin-tailwindcss": "^0.6.14",
     "supabase": "^2.31.8",
     "tailwindcss": "^4",
     "tw-animate-css": "^1.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,12 @@ importers:
       eslint-plugin-react-hooks:
         specifier: ^5.2.0
         version: 5.2.0(eslint@9.31.0(jiti@2.4.2))
+      prettier:
+        specifier: ^3.6.2
+        version: 3.6.2
+      prettier-plugin-tailwindcss:
+        specifier: ^0.6.14
+        version: 0.6.14(prettier@3.6.2)
       supabase:
         specifier: ^2.31.8
         version: 2.31.8
@@ -2387,6 +2393,72 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
+
+  prettier-plugin-tailwindcss@0.6.14:
+    resolution: {integrity: sha512-pi2e/+ZygeIqntN+vC573BcW5Cve8zUB0SSAGxqpB4f96boZF4M3phPVoOFCeypwkpRYdi7+jQ5YJJUwrkGUAg==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-hermes': '*'
+      '@prettier/plugin-oxc': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-hermes':
+        optional: true
+      '@prettier/plugin-oxc':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
+
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+    engines: {node: '>=14'}
+    hasBin: true
 
   proc-log@5.0.0:
     resolution: {integrity: sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ==}
@@ -5160,6 +5232,12 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
+
+  prettier-plugin-tailwindcss@0.6.14(prettier@3.6.2):
+    dependencies:
+      prettier: 3.6.2
+
+  prettier@3.6.2: {}
 
   proc-log@5.0.0: {}
 


### PR DESCRIPTION
This adds the Prettier formatter and a plugin for it.

Running pnpm format [path to file] will make it adhere to some formatting practices including canonical tailwind class ordering which is good

Considering running a rull format on the repo which will change tons of files once off but standardize us on spacing indents etc