### PR TITLE
only show profiles on homepage if homepage_order is non-null (instead of just putting those profiles at the end)

### DIFF
--- a/app/actions/db/profiles/queries.ts
+++ b/app/actions/db/profiles/queries.ts
@@ -10,7 +10,7 @@ export async function getSpeakersFromProfiles() {
     .select()
     .eq('opted_in_to_homepage_display', true)
     .not('homepage_order', 'is', null)
-    .order('homepage_order', { ascending: true, nullsFirst: false });
+    .order('homepage_order', { ascending: true });
 
   if (error) {
     console.error('Error fetching speakers from profiles:', error);

--- a/app/actions/db/profiles/queries.ts
+++ b/app/actions/db/profiles/queries.ts
@@ -9,6 +9,7 @@ export async function getSpeakersFromProfiles() {
     .from('profiles')
     .select()
     .eq('opted_in_to_homepage_display', true)
+    .not('homepage_order', 'is', null)
     .order('homepage_order', { ascending: true, nullsFirst: false });
 
   if (error) {


### PR DESCRIPTION
changing the profile process so that only the ones with homepage_order defined appear on the homepage. a future PR will give the ability for users to "shuffle" which will select a subset of cards randomly from all who have opted into being on the homepage