### PR TITLE
adds supabase type sync before dev and build commands for updated types

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
-    "build": "next build",
+    "dev": "pnpm types:supabase && next dev",
+    "build": "pnpm types:supabase && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "playwright test",


### PR DESCRIPTION
This adds `pnpm types:supabase` before build and dev deploy commands so that we avoid linting errors with slightly updated supabase types