### PR TITLE
Resetpassword

### DIFF
--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -12,6 +12,7 @@ import { toast } from 'sonner'
 import { LinkIcon } from 'lucide-react'
 import { toExternalLink, uploadFileWithSignedUrl } from '@/lib/utils'
 import { useMutation, useQueryClient } from '@tanstack/react-query'
+import Link from 'next/link'
 
 export default function Profile() {
   const { currentUser, currentUserProfile, currentUserLoading } = useUser()
@@ -333,6 +334,15 @@ export default function Profile() {
                 </Link>
               )}
             </div>
+            {isEditMode && (
+              <div className="flex flex-col gap-2">
+                <Link href="/profile/reset-password">
+                  <Button variant="outline" size="sm">
+                    Reset Password
+                  </Button>
+                </Link>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useRef, useEffect } from 'react'
 import Image from 'next/image'
-import Link from 'next/link'
 import { useUser } from '@/hooks/dbQueries'
 import { updateCurrentUserProfile, deleteCurrentUserProfilePicture } from '@/app/actions/db/users'
 import { getCurrentUserProfilePictureUploadUrl } from '@/app/actions/db/storage'

--- a/app/profile/reset-password/page.tsx
+++ b/app/profile/reset-password/page.tsx
@@ -13,6 +13,7 @@ export default function ResetPasswordPage() {
     password: "",
     confirmPassword: "",
   });
+  
   const [errors, setErrors] = useState<PasswordErrors>({});
   const [isLoading, setIsLoading] = useState(false);
 
@@ -42,7 +43,7 @@ export default function ResetPasswordPage() {
       if (error) {
         setErrors({ submit: error.message });
       } else {
-        router.push("/");
+        router.push("/profile/reset-password/success");
       }
     } catch (error) {
       if (error instanceof z.ZodError) {

--- a/app/profile/reset-password/page.tsx
+++ b/app/profile/reset-password/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { z } from "zod";
 import { LockIcon } from "lucide-react";
 import { passwordSchema, type PasswordErrors } from "@/lib/schemas/password";
+import { Input } from "@/components/ui/input";
 
 export default function ResetPasswordPage() {
   const router = useRouter();
@@ -13,7 +14,8 @@ export default function ResetPasswordPage() {
     password: "",
     confirmPassword: "",
   });
-  
+  const [nonce, setNonce] = useState<string | null>(null);
+  const [reauthNeeded, setReauthNeeded] = useState(false);
   const [errors, setErrors] = useState<PasswordErrors>({});
   const [isLoading, setIsLoading] = useState(false);
 
@@ -35,13 +37,21 @@ export default function ResetPasswordPage() {
     try {
       const validatedData = passwordSchema.parse(formData);
       const supabase = createClient();
-
-      const { error } = await supabase.auth.updateUser({
+      
+      const { data, error } = await supabase.auth.updateUser({
         password: validatedData.password,
+        nonce: nonce ?? undefined,
       });
-
+      console.log(`"data": ${JSON.stringify(data)}`);
+      console.log(`"error": ${JSON.stringify(error)}`);
+      console.log(`"nonce": ${nonce}`);
       if (error) {
-        setErrors({ submit: error.message });
+        if (error.code === "needs_reauthentication" || error.code === "reauth_nonce_missing") {
+          setReauthNeeded(true);
+          await supabase.auth.reauthenticate();
+        } else {
+          setErrors({ submit: error.message });
+        }
       } else {
         router.push("/profile/reset-password/success");
       }
@@ -143,7 +153,20 @@ export default function ResetPasswordPage() {
               </span>
             )}
           </div>
-
+          {reauthNeeded && (
+            <div className="flex flex-col gap-2">
+              <div className="text-red-400 text-sm text-center">
+              ⚠ You need to reauthenticate to set your password. Enter the code sent to your email to continue. ⚠
+              </div>
+              <Input
+                type="text"
+                value={nonce || ""}
+                onChange={(e) => setNonce(e.target.value)}
+                required
+                className="w-full"
+              />
+            </div>
+          )}
           {errors.submit && (
             <div className="text-red-500 text-sm text-center">
               {errors.submit}

--- a/app/profile/reset-password/success/page.tsx
+++ b/app/profile/reset-password/success/page.tsx
@@ -1,0 +1,43 @@
+import { buttonVariants } from "@/components/ui/button";
+import Link from "next/link";
+
+export default function ResetPasswordSuccessPage() {
+  return (
+    <div className="min-h-[80vh] flex items-center justify-center">
+      <div className="bg-dark-400 p-8 rounded-lg shadow-lg w-full max-w-md text-center">
+        <div className="flex flex-col items-center gap-4">
+          <div className="bg-green-600 rounded-full p-3 mb-2">
+            <svg
+              className="w-8 h-8 text-white"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={2.5}
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M5 13l4 4L19 7"
+              />
+            </svg>
+          </div>
+          <h1 className="text-2xl font-bold mb-2">Password Changed!</h1>
+          <p className="text-lg text-gray-300 mb-4">
+            Your password has been updated successfully.
+          </p>
+          <div className="flex gap-4">
+              <Link
+                href="/profile"
+                className={buttonVariants({ variant: 'outline' })}
+              >
+                Go to Profile
+              </Link>
+              <Link href="/" className={buttonVariants({ variant: 'outline' })}>
+                Go to Home
+              </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/schedule/EditEventModal.tsx
+++ b/app/schedule/EditEventModal.tsx
@@ -24,7 +24,6 @@ import { DbSessionAges } from "@/types/database/dbTypeAliases";
 import {
   getAgesDisplayText,
   SESSION_AGES,
-  SESSION_AGES,
   SessionAgesEnum,
 } from "@/utils/dbUtils";
 import { XIcon } from "lucide-react";

--- a/app/schedule/EditEventModal.tsx
+++ b/app/schedule/EditEventModal.tsx
@@ -24,6 +24,7 @@ import { DbSessionAges } from "@/types/database/dbTypeAliases";
 import {
   getAgesDisplayText,
   SESSION_AGES,
+  SESSION_AGES,
   SessionAgesEnum,
 } from "@/utils/dbUtils";
 import { XIcon } from "lucide-react";


### PR DESCRIPTION
This updates the reset password flow

-adds a link to the reset password page from profile
-adds a success splash after changing password
-adds a reauth flow handling so that signed in users with stale sessions (>24 hours since logged in) can enter an OTP to verify before resetting their password