### PR TITLE
Add #schedule anchor to home page schedule section

### DIFF
--- a/components/sections/home/ScheduleSection.tsx
+++ b/components/sections/home/ScheduleSection.tsx
@@ -3,7 +3,10 @@ import ScheduleProvider from '@/app/schedule/ScheduleProvider'
 
 export default function ScheduleSection() {
   return (
-    <section className="mb-10 flex h-fit w-full max-w-full flex-col justify-center gap-2 overflow-hidden">
+    <section
+      id="schedule"
+      className="mb-10 flex h-fit w-full max-w-full flex-col justify-center gap-2 overflow-hidden"
+    >
       <h2 className="mb-4 text-center text-3xl font-bold">Schedule</h2>
       <p className="mb-8 text-center text-primary-200">
         Times, locations, content, hosts, and the fundamental fabric of reality


### PR DESCRIPTION
Adds `id="schedule"` to the home page's schedule `<section>` so external links can deep-link and scroll directly to it (matches the existing `#speakers` / `#sponsors` anchors).

This unblocks the companion metagame-2026 change, whose "last year's schedule" link points at `https://2025.metagame.games/#schedule`. Needs to ship/deploy for that anchor to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)