### PR TITLE
Smaller speaker cards on mobile (3 per row)

### DIFF
--- a/components/sections/home/speakers/SpeakersGrid.tsx
+++ b/components/sections/home/speakers/SpeakersGrid.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useEffect, useState } from 'react'
+
 import Link from 'next/link'
 
 import PlayerCard from '@/components/PlayerCard/PlayerCard'
@@ -10,7 +12,21 @@ interface SpeakersGridProps {
   speakerIds: string[]
 }
 
+// Smaller cards on mobile so the grid fits 3 per row instead of 2; PlayerCard
+// scales everything off this width. Keyed to Tailwind's sm breakpoint.
+function useSpeakerCardWidth() {
+  const [width, setWidth] = useState(150)
+  useEffect(() => {
+    const update = () => setWidth(window.innerWidth < 640 ? 104 : 150)
+    update()
+    window.addEventListener('resize', update)
+    return () => window.removeEventListener('resize', update)
+  }, [])
+  return width
+}
+
 export default function SpeakersGrid({ speakerIds }: SpeakersGridProps) {
+  const cardWidth = useSpeakerCardWidth()
   const { profiles, profilesLoading, profilesError } = usePublicProfiles({
     userIds: speakerIds,
     includeFullProfiles: false,
@@ -60,7 +76,7 @@ export default function SpeakersGrid({ speakerIds }: SpeakersGridProps) {
               asCelestialCard={false}
               tiltFactor={1}
               gleamFollowsTilt
-              width={150}
+              width={cardWidth}
             />
           </div>
         </div>


### PR DESCRIPTION
On mobile the speaker grid only fit **2 cards per row**, so it took a lot of scrolling. `PlayerCard` scales everything off its `width` prop, so this just drops the mobile width from 150→104 (below the `sm` breakpoint), giving smaller cards and **3 per row**. Desktop is untouched.

- New `useSpeakerCardWidth` hook picks 104 under `sm` (640px), 150 above. The grid is already client-rendered behind a loading state, so there's no SSR flash.
- Cards <200px already render in the compact "tiny" layout (name + photo), so going smaller stays clean.

## Review on mobile
Open the Vercel preview on your phone and check the card size / row count feels right. The width is a single number (`104`) — easy to nudge if you want them a touch bigger/smaller, or `~76` would give 4 per row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)