### PR TITLE
Reserve the speakers grid's height while it loads

### DIFF
--- a/components/PlayerCard/PlayerCard.tsx
+++ b/components/PlayerCard/PlayerCard.tsx
@@ -56,6 +56,60 @@ const TALL_BANNER_HEIGHT = 203 // the inside height of the tall top banner (hold
 const TIP_TOP_FRAME = 6 // the width of the very outermost frame edge of the frame
 const NO_ABILITY_BIO_CHAR_LIMIT = 330 // different char limit for when we do not need space for abilities
 const PICTURE_HEIGHT = CARD_HEIGHT / 2 // height of framed profile picture
+// The gray-wash card frame shown while a profile loads (or, with state="error",
+// when its fetch fails). Exported so callers can lay out a full-size pending
+// grid before the data arrives without mounting data-fetching cards.
+export function PlayerCardSkeleton({
+  width = 300,
+  state = 'loading',
+}: {
+  width?: number
+  state?: 'loading' | 'error'
+}) {
+  const scale = width / CARD_WIDTH
+  return (
+    <div
+      className="pointer-events-none relative max-w-full overflow-hidden rounded-[2px] font-imfell text-celestial-primary"
+      style={{
+        width: width,
+        aspectRatio: CARD_WIDTH / CARD_HEIGHT,
+        fontSize: 500 * scale,
+      }}
+    >
+      {/* Background card image - gray wash */}
+      <Image
+        src="/images/cards/fog.gif"
+        alt=""
+        fill
+        className="z-1 object-cover"
+      />
+      <Image
+        src="/images/cards/gray-wash.png"
+        alt=""
+        fill
+        className="z-2 object-cover opacity-50"
+      />
+      {/* Frame Overlay */}
+      <Image
+        src="/images/cards/celestial-frame-2x3-shortbanner.png"
+        alt=""
+        fill
+        className="pointer-events-none z-3 object-cover"
+      />
+
+      {/* Centered status glyph */}
+      <div className="absolute inset-0 z-2 flex items-center justify-center">
+        <div className="flex flex-col items-center text-celestial-gray">
+          <span>{state === 'error' ? 'X' : '?'}</span>
+          <span style={{ fontSize: 100 * scale }}>
+            {state === 'error' ? 'Error' : 'Loading...'}
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
 export default function PlayerCard({
   userId,
   tiltFactor = 0,
@@ -116,56 +170,16 @@ export default function PlayerCard({
     (profile?.last_name?.length || 0) +
     ((!isTiny && profile?.pronouns?.length) || 0) +
     (profile?.minor ? 1 : 0)
-  // Loading state - show gray wash, question mark, and frame
+  // No profile to show yet. Only a genuine query error is "Error"; a still-
+  // fetching or enabled-but-not-yet-started tick (data momentarily undefined
+  // while isLoading is false) is treated as loading, so cards never flash
+  // "Error" just because data hasn't landed.
   if (profileLoading || profileError || !profile) {
     return (
-      <div
-        className="pointer-events-none relative max-w-full overflow-hidden rounded-[2px] font-imfell text-celestial-primary"
-        style={{
-          width: width,
-          aspectRatio: CARD_WIDTH / CARD_HEIGHT,
-          fontSize: 500 * scale,
-        }}
-      >
-        {/* Background card image - gray wash */}
-        <Image
-          src="/images/cards/fog.gif"
-          alt="Loading..."
-          fill
-          className="z-1 object-cover"
-        />
-        <Image
-          src="/images/cards/gray-wash.png"
-          alt="Loading..."
-          fill
-          className="z-2 object-cover opacity-50"
-        />
-        {/* Frame Overlay */}
-        <Image
-          src="/images/cards/celestial-frame-2x3-shortbanner.png"
-          alt="Frame overlay"
-          fill
-          className="pointer-events-none z-3 object-cover"
-        />
-
-        {/* Large question mark in center */}
-        <div
-          // style={{
-          //   width: INNER_WIDTH * scale,
-          //   height: PICTURE_HEIGHT * scale,
-          //   top: TOP_FROM_TOP * scale,
-          //   left: FRAME_FROM_EDGE * scale,
-          // }}
-          className="absolute inset-0 z-2 flex items-center justify-center"
-        >
-          <div className="flex flex-col items-center text-celestial-gray">
-            <span>{profileLoading ? '?' : 'X'}</span>
-            <span style={{ fontSize: 100 * scale }}>
-              {profileLoading ? 'Loading...' : 'Error'}
-            </span>
-          </div>
-        </div>
-      </div>
+      <PlayerCardSkeleton
+        width={width}
+        state={profileError ? 'error' : 'loading'}
+      />
     )
   }
   const celestialCard = overrideCelestialCard ?? profile?.celestial_card ?? null

--- a/components/sections/home/speakers/SpeakersGrid.tsx
+++ b/components/sections/home/speakers/SpeakersGrid.tsx
@@ -4,7 +4,9 @@ import { useEffect, useState } from 'react'
 
 import Link from 'next/link'
 
-import PlayerCard from '@/components/PlayerCard/PlayerCard'
+import PlayerCard, {
+  PlayerCardSkeleton,
+} from '@/components/PlayerCard/PlayerCard'
 
 import { usePublicProfiles } from '@/hooks/useProfiles'
 
@@ -39,10 +41,18 @@ export default function SpeakersGrid({ speakerIds }: SpeakersGridProps) {
     )
   }
 
-  // Still loading profiles
+  // While the batch fetch is in flight, render one pending card frame per known
+  // speaker. This reserves the grid's real height so the #speakers anchor never
+  // briefly frames the Sponsors section, and the single batch request seeds each
+  // card's cache — so the real cards below render straight from cache, with no
+  // per-card re-fetch and no "loading→error" flash.
   if (profilesLoading) {
     return (
-      <div className="text-lg text-muted-foreground">Loading Speakers...</div>
+      <>
+        {speakerIds.map((id) => (
+          <PlayerCardSkeleton key={id} width={cardWidth} />
+        ))}
+      </>
     )
   }
 

--- a/components/sections/home/speakers/index.tsx
+++ b/components/sections/home/speakers/index.tsx
@@ -1,5 +1,7 @@
 import SpeakersGrid from './SpeakersGrid'
 
+import { PlayerCardSkeleton } from '@/components/PlayerCard/PlayerCard'
+
 import { getSpeakerIds } from '@/app/actions/db/users'
 
 export default async function Speakers() {
@@ -25,11 +27,11 @@ export function SpeakersLoading() {
         <h2 className="mb-8 text-center text-3xl font-bold">Speakers</h2>
 
         <div className="max-w-8xl mx-auto flex flex-wrap justify-center gap-2 sm:gap-4 md:gap-6">
-          <div className="flex items-center justify-center p-8">
-            <div className="text-lg text-muted-foreground">
-              Loading Speakers...
-            </div>
-          </div>
+          {/* Pending card frames reserve vertical space before the speaker IDs
+              resolve, so the #speakers anchor doesn't briefly frame Sponsors. */}
+          {Array.from({ length: 12 }).map((_, i) => (
+            <PlayerCardSkeleton key={i} width={150} />
+          ))}
         </div>
       </div>
     </section>


### PR DESCRIPTION
Navigating to `#speakers` briefly framed the Sponsors section: the grid collapsed to a one-line "Loading Speakers..." until profiles arrived, so the anchor landed with Sponsors in view before the cards popped in and shoved it down.

Now the grid renders one pending `PlayerCard` frame per known speaker while the batch profile fetch is in flight, reserving its real height. The single batch request seeds each card's cache, so the real cards then render straight from cache — no per-card refetch, no height jump.

- Extracted the gray-wash card frame into an exported `PlayerCardSkeleton` (used by the grid, the Suspense fallback, and `PlayerCard`'s own loading branch).
- Fixed a latent mislabel: `PlayerCard` treated *any* absent profile as "Error". A still-fetching or enabled-but-not-yet-started tick (data `undefined` while `isLoading` is `false`) now reads as loading, so cards no longer flash "Error" before data lands — everywhere `PlayerCard` is used.

## Already verified
- `pnpm typecheck`, `eslint --max-warnings=0`, `prettier --check` all pass.
- Exercised locally against the prod Supabase project: `#speakers` lands at full grid height in the gray-wash pending state, then fills in — no Sponsors flash, no "Error" flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)