### PR TITLE
Filter the schedule by location, shareable via ?locations=

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -105,14 +105,34 @@
   --font-imfell: 'IM Fell English', ui-serif, serif, 'Apple Color Emoji';
   --font-cinzel: 'Cinzel', ui-serif, serif, 'Apple Color Emoji';
   --font-mulish:
-    'Mulish', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji',
-    /* Keyframes */ --animate-coin-pop: coin-pop 0.6s ease-out;
+    'Mulish', ui-sans-serif, system-ui, sans-serif, 'Apple Color Emoji';
+
+  /* Keyframes */
+  --animate-coin-pop: coin-pop 0.6s ease-out;
   --animate-fade-in: fade-in 0.5s ease-in forwards;
   --animate-fade-out: fade-out 0.5s linear forwards;
   --animate-flash: flash 2s linear infinite;
+  --animate-filter-active: filter-active 3.5s ease-in-out infinite;
 }
 
 /* Keyframe definitions */
+@keyframes filter-active {
+  0%,
+  100% {
+    background-color: color-mix(
+      in oklab,
+      var(--color-sky-300) 10%,
+      transparent
+    );
+  }
+  50% {
+    background-color: color-mix(
+      in oklab,
+      var(--color-sky-300) 30%,
+      transparent
+    );
+  }
+}
 @keyframes coin-pop {
   0% {
     transform: translateY(0) translateX(-50%) scale(0.5);

--- a/app/schedule/LocationFilterMenu.tsx
+++ b/app/schedule/LocationFilterMenu.tsx
@@ -1,5 +1,7 @@
 'use client'
 
+import { useState } from 'react'
+
 import { CheckIcon, FilterIcon, MinusIcon } from 'lucide-react'
 
 import {
@@ -25,6 +27,8 @@ export function LocationFilterMenu({
   selected: string[]
   onChange: (values: string[]) => void
 }) {
+  const [open, setOpen] = useState(false)
+
   const allSelected = selected.length === options.length
   const noneSelected = selected.length === 0
   const isFiltering = !allSelected
@@ -45,7 +49,7 @@ export function LocationFilterMenu({
   const itemClass = 'cursor-pointer focus:bg-dark-400 focus:text-secondary-100'
 
   return (
-    <DropdownMenu>
+    <DropdownMenu open={open} onOpenChange={setOpen}>
       <Tooltip>
         <TooltipTrigger asChild>
           <DropdownMenuTrigger
@@ -67,7 +71,8 @@ export function LocationFilterMenu({
       >
         <DropdownMenuItem
           onSelect={(e) => {
-            e.preventDefault()
+            // Clearing is usually a prelude to picking a few, so stay open for it
+            if (allSelected) e.preventDefault()
             toggleAll()
           }}
           className={`${itemClass} relative pl-8`}
@@ -98,6 +103,7 @@ export function LocationFilterMenu({
                 e.preventDefault()
                 e.stopPropagation()
                 onChange([option.value])
+                setOpen(false)
               }}
               className="rounded-sm px-1 text-xs text-secondary-400 opacity-0 group-hover:opacity-100 hover:bg-dark-300 hover:text-secondary-100"
             >

--- a/app/schedule/LocationFilterMenu.tsx
+++ b/app/schedule/LocationFilterMenu.tsx
@@ -1,0 +1,111 @@
+'use client'
+
+import { CheckIcon, FilterIcon, MinusIcon } from 'lucide-react'
+
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+
+export function LocationFilterMenu({
+  options,
+  selected,
+  onChange,
+}: {
+  options: { value: string; label: string }[]
+  selected: string[]
+  onChange: (values: string[]) => void
+}) {
+  const allSelected = selected.length === options.length
+  const noneSelected = selected.length === 0
+  const isFiltering = !allSelected
+
+  const toggle = (value: string) => {
+    onChange(
+      selected.includes(value)
+        ? selected.filter((v) => v !== value)
+        : [...selected, value],
+    )
+  }
+
+  // Partial counts as "not all", so clicking it selects everything — the way back
+  // to the unfiltered schedule is always one click
+  const toggleAll = () =>
+    onChange(allSelected ? [] : options.map((option) => option.value))
+
+  const itemClass = 'cursor-pointer focus:bg-dark-400 focus:text-secondary-100'
+
+  return (
+    <DropdownMenu>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <DropdownMenuTrigger
+            className={`${isFiltering ? 'opacity-100' : 'opacity-50'} cursor-pointer rounded-sm p-0.5 transition-colors hover:bg-dark-300 hover:opacity-100`}
+          >
+            <FilterIcon
+              fill={isFiltering ? 'currentColor' : 'none'}
+              className="size-4 text-secondary-300"
+            />
+          </DropdownMenuTrigger>
+        </TooltipTrigger>
+        <TooltipContent>
+          {isFiltering ? 'Locations filtered' : 'Filter locations'}
+        </TooltipContent>
+      </Tooltip>
+      <DropdownMenuContent
+        align="start"
+        className="max-h-[60vh] overflow-y-auto border-secondary-300 bg-dark-600 font-serif text-secondary-200"
+      >
+        <DropdownMenuItem
+          onSelect={(e) => {
+            e.preventDefault()
+            toggleAll()
+          }}
+          className={`${itemClass} relative pl-8`}
+        >
+          <span className="pointer-events-none absolute left-2 flex size-3.5 items-center justify-center">
+            {allSelected && <CheckIcon className="size-4" />}
+            {!allSelected && !noneSelected && <MinusIcon className="size-4" />}
+          </span>
+          {allSelected ? 'Clear all' : 'Select all'}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator className="bg-secondary-300" />
+        {options.map((option) => (
+          <DropdownMenuCheckboxItem
+            key={option.value}
+            checked={selected.includes(option.value)}
+            // Keep the menu open so several locations can be picked in one go
+            onSelect={(e) => e.preventDefault()}
+            onCheckedChange={() => toggle(option.value)}
+            className={`${itemClass} group justify-between gap-6`}
+          >
+            <span>{option.label}</span>
+            <span
+              role="button"
+              tabIndex={-1}
+              title={`Show only ${option.label}`}
+              onPointerDown={(e) => e.stopPropagation()}
+              onClick={(e) => {
+                e.preventDefault()
+                e.stopPropagation()
+                onChange([option.value])
+              }}
+              className="rounded-sm px-1 text-xs text-secondary-400 opacity-0 group-hover:opacity-100 hover:bg-dark-300 hover:text-secondary-100"
+            >
+              only
+            </span>
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/app/schedule/Schedule.tsx
+++ b/app/schedule/Schedule.tsx
@@ -157,6 +157,12 @@ export default function Schedule({
 
   const isLocationFiltered = locationFilter !== null
 
+  // repeat(0, ...) is invalid CSS — the browser drops the whole declaration and
+  // keeps the previous track list, leaving a full-width grid with no columns in it
+  const gridTemplateColumns = scheduleLocations.length
+    ? `60px repeat(${scheduleLocations.length}, minmax(180px, 360px))`
+    : '60px'
+
   const handleLocationFilterChange = (slugs: string[]) => {
     // Selecting everything is the same as no filter; collapse so the URL stays clean
     setLocationFilter(
@@ -419,9 +425,7 @@ export default function Schedule({
           {/* Images Row - Scrollable on mobile, sticky on large */}
           <div
             className="grid w-fit bg-dark-400 lg:top-0 lg:z-30"
-            style={{
-              gridTemplateColumns: `60px repeat(${scheduleLocations.length}, minmax(180px, 360px))`,
-            }}
+            style={{ gridTemplateColumns }}
           >
             <div
               className={`sticky left-0 z-30 border border-b-0 border-secondary-300 bg-dark-600 p-3 ${isLocationFiltered ? 'animate-filter-active' : ''}`}
@@ -465,9 +469,7 @@ export default function Schedule({
           {/* Names Row - Always sticky, with day nav on mobile */}
           <div
             className="sticky top-0 z-20 grid w-fit bg-dark-400"
-            style={{
-              gridTemplateColumns: `60px repeat(${scheduleLocations.length}, minmax(180px, 360px))`,
-            }}
+            style={{ gridTemplateColumns }}
           >
             <div
               className={`sticky top-0 left-0 z-30 border border-t-0 border-b-2 border-secondary-300 bg-dark-600 p-3 ${isLocationFiltered ? 'animate-filter-active' : ''}`}
@@ -521,18 +523,10 @@ export default function Schedule({
             ))}
           </div>
 
-          {scheduleLocations.length === 0 && (
-            <div className="p-8 text-center text-sm text-secondary-300">
-              No locations selected — pick some from the filter menu.
-            </div>
-          )}
-
           {/* Time Slots Grid */}
           <div
             className={`relative grid w-fit bg-dark-400 ${scheduleLocations.length === 0 ? 'hidden' : ''}`}
-            style={{
-              gridTemplateColumns: `60px repeat(${scheduleLocations.length}, minmax(180px, 360px))`,
-            }}
+            style={{ gridTemplateColumns }}
           >
             {generateTimeSlots(currentDayIndex).map((time) => (
               <div key={time} className="contents">
@@ -700,6 +694,12 @@ export default function Schedule({
           </div>
         </div>
       </div>
+
+      {scheduleLocations.length === 0 && (
+        <div className="w-full p-8 text-center text-sm text-secondary-300">
+          No locations selected — pick some from the filter menu.
+        </div>
+      )}
 
       {openedSession && (
         <Dialog

--- a/app/schedule/Schedule.tsx
+++ b/app/schedule/Schedule.tsx
@@ -4,10 +4,12 @@ import { useEffect, useMemo, useState } from 'react'
 
 import { AddEventModal } from './EditEventModal'
 import { HostListLinks } from './HostListLinks'
+import { LocationFilterMenu } from './LocationFilterMenu'
 import { AttendanceDisplay } from './RSVPList'
 import SessionDetailsCard from './SessionModalCard'
 import { SessionTooltip } from './SessionTooltip'
 import { scheduleColors } from './scheduleColors'
+import { locationSlug } from './scheduleUtils'
 import {
   ArrowLeftIcon,
   ArrowRightIcon,
@@ -101,10 +103,12 @@ const getEventDurationMinutes = (session: DbFullSession) => {
 export default function Schedule({
   sessionId,
   dayIndex,
+  locationSlugs,
   editPermissions,
 }: {
   sessionId?: string
   dayIndex?: number
+  locationSlugs?: string[]
   editPermissions: Record<string, boolean>
 }) {
   const pathname = usePathname()
@@ -121,11 +125,44 @@ export default function Schedule({
   } = useScheduleStuff()
 
   // Filter and sort locations for schedule display
-  const scheduleLocations = useMemo(() => {
+  const allScheduleLocations = useMemo(() => {
     return locations
       .filter((location) => location.display_in_schedule) // Only show locations that should be displayed in schedule
       .sort((a, b) => a.schedule_display_order - b.schedule_display_order) // Sort by display order
   }, [locations])
+
+  // null = unfiltered (every location shown, no ?locations= in the URL)
+  const [locationFilter, setLocationFilter] = useState<string[] | null>(
+    locationSlugs ?? null,
+  )
+
+  const locationFilterOptions = useMemo(
+    () =>
+      allScheduleLocations.map((location) => ({
+        value: locationSlug(location.name),
+        label: location.name,
+      })),
+    [allScheduleLocations],
+  )
+
+  const selectedLocationSlugs =
+    locationFilter ?? locationFilterOptions.map((option) => option.value)
+
+  const scheduleLocations = useMemo(() => {
+    if (!locationFilter) return allScheduleLocations
+    return allScheduleLocations.filter((location) =>
+      locationFilter.includes(locationSlug(location.name)),
+    )
+  }, [allScheduleLocations, locationFilter])
+
+  const isLocationFiltered = locationFilter !== null
+
+  const handleLocationFilterChange = (slugs: string[]) => {
+    // Selecting everything is the same as no filter; collapse so the URL stays clean
+    setLocationFilter(
+      slugs.length === locationFilterOptions.length ? null : slugs,
+    )
+  }
 
   const [filterForUserEvents, setFilterForUserEvents] = useState(false)
 
@@ -210,12 +247,14 @@ export default function Schedule({
     if (currentDayIndex !== 0) params.set('day', currentDayIndex.toString())
     if (openedSessionId) params.set('session', openedSessionId)
     if (!openedSessionId) params.delete('session')
+    if (locationFilter?.length)
+      params.set('locations', locationFilter.join(','))
 
     const newUrl = params.toString()
       ? `?${params.toString()}`
       : window.location.pathname
     router.replace(newUrl, { scroll: false })
-  }, [currentDayIndex, openedSessionId, router])
+  }, [currentDayIndex, openedSessionId, locationFilter, router])
 
   const currentDay = days[currentDayIndex] || {
     date: '',
@@ -325,7 +364,7 @@ export default function Schedule({
   }, [])
 
   return (
-    <div className="flex flex-col rounded-2xl bg-dark-500 font-serif">
+    <div className="flex w-fit max-w-full flex-col rounded-2xl bg-dark-500 font-serif">
       <div className="grid grid-cols-[1fr_auto_1fr] items-center border-b border-secondary-300 bg-dark-600 p-4">
         <button
           onClick={prevDay}
@@ -375,17 +414,19 @@ export default function Schedule({
       </div>
 
       {/* Scrollable Schedule Content */}
-      <div className="no-scrollbar flex-1 overflow-x-auto overflow-y-hidden">
+      <div className="no-scrollbar max-w-full flex-1 overflow-x-auto overflow-y-hidden">
         <div className="h-fit min-w-fit">
           {/* Images Row - Scrollable on mobile, sticky on large */}
           <div
-            className="grid bg-dark-400 lg:top-0 lg:z-30"
+            className="grid w-fit bg-dark-400 lg:top-0 lg:z-30"
             style={{
-              gridTemplateColumns: `60px repeat(${scheduleLocations.length}, minmax(180px, 1fr))`,
+              gridTemplateColumns: `60px repeat(${scheduleLocations.length}, minmax(180px, 360px))`,
             }}
           >
-            <div className="sticky left-0 z-30 border border-secondary-300 bg-dark-600 p-3">
-              {/* Empty space above time column */}
+            <div
+              className={`sticky left-0 z-30 border border-b-0 border-secondary-300 bg-dark-600 p-3 ${isLocationFiltered ? 'animate-filter-active' : ''}`}
+            >
+              {/* Merged with the filter cell below it — both rows are location headers */}
             </div>
             {scheduleLocations.map((location) => (
               <div
@@ -393,14 +434,14 @@ export default function Schedule({
                 className="border border-secondary-300 bg-dark-600 p-3"
               >
                 {location.name === 'The Clocktower' ? (
-                  <BloodDrippingFrame className="z-1 h-24 w-full">
+                  <BloodDrippingFrame className="z-1 mx-auto h-24 w-fit">
                     {location.thumbnail_url ? (
                       <Image
                         src={location.thumbnail_url}
                         alt={location.name}
                         width={100}
                         height={100}
-                        className="h-24 w-full object-cover"
+                        className="h-24 w-auto max-w-full object-cover"
                       />
                     ) : (
                       <div className="h-24 w-full bg-dark-500" />
@@ -412,7 +453,7 @@ export default function Schedule({
                     alt={location.name}
                     width={100}
                     height={100}
-                    className="h-24 w-full object-cover"
+                    className="mx-auto h-24 w-auto max-w-full object-cover"
                   />
                 ) : (
                   <div className="h-24 w-full bg-dark-500" />
@@ -423,13 +464,20 @@ export default function Schedule({
 
           {/* Names Row - Always sticky, with day nav on mobile */}
           <div
-            className="sticky top-0 z-20 grid bg-dark-400"
+            className="sticky top-0 z-20 grid w-fit bg-dark-400"
             style={{
-              gridTemplateColumns: `60px repeat(${scheduleLocations.length}, minmax(180px, 1fr))`,
+              gridTemplateColumns: `60px repeat(${scheduleLocations.length}, minmax(180px, 360px))`,
             }}
           >
-            <div className="sticky top-0 left-0 z-30 border border-b-2 border-secondary-300 bg-dark-600 p-3">
+            <div
+              className={`sticky top-0 left-0 z-30 border border-t-0 border-b-2 border-secondary-300 bg-dark-600 p-3 ${isLocationFiltered ? 'animate-filter-active' : ''}`}
+            >
               <div className="sticky flex size-full flex-col items-center justify-center gap-4 text-sm font-medium text-secondary-300">
+                <LocationFilterMenu
+                  options={locationFilterOptions}
+                  selected={selectedLocationSlugs}
+                  onChange={handleLocationFilterChange}
+                />
                 {currentUserProfile?.id && (
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -473,11 +521,17 @@ export default function Schedule({
             ))}
           </div>
 
+          {scheduleLocations.length === 0 && (
+            <div className="p-8 text-center text-sm text-secondary-300">
+              No locations selected — pick some from the filter menu.
+            </div>
+          )}
+
           {/* Time Slots Grid */}
           <div
-            className="relative grid bg-dark-400"
+            className={`relative grid w-fit bg-dark-400 ${scheduleLocations.length === 0 ? 'hidden' : ''}`}
             style={{
-              gridTemplateColumns: `60px repeat(${scheduleLocations.length}, minmax(180px, 1fr))`,
+              gridTemplateColumns: `60px repeat(${scheduleLocations.length}, minmax(180px, 360px))`,
             }}
           >
             {generateTimeSlots(currentDayIndex).map((time) => (

--- a/app/schedule/ScheduleProvider.tsx
+++ b/app/schedule/ScheduleProvider.tsx
@@ -3,6 +3,7 @@ import { getAllSessions } from '../actions/db/sessions'
 import { getCurrentUserFullProfile } from '../actions/db/users'
 import Schedule from './Schedule'
 import { getUserEditPermissionsForSessions } from './actions'
+import { locationSlug } from './scheduleUtils'
 import {
   HydrationBoundary,
   QueryClient,
@@ -13,16 +14,18 @@ import { createClient } from '@/utils/supabase/server'
 
 import { currentUserGetSessionBookmarks } from '@/app/actions/db/sessionBookmarks'
 
-import { DbFullSession } from '@/types/database/dbTypeAliases'
+import { DbFullSession, DbLocation } from '@/types/database/dbTypeAliases'
 
 // import { fetchSessions, fetchCurrentUserRsvps, fetchLocations } from "./queries"
 
 export default async function ScheduleProvider({
   sessionId,
   dayIndex,
+  locationSlugs,
 }: {
   sessionId?: string
   dayIndex?: number
+  locationSlugs?: string[]
 }) {
   const queryClient = new QueryClient()
   // Get current user for edit permissions
@@ -61,6 +64,15 @@ export default async function ScheduleProvider({
     await Promise.all(userPrefetchQueries.map((query) => query()))
   }
 
+  // Drop ?locations= slugs that match nothing, so a stale link renders the full schedule
+  // rather than an empty grid
+  const knownLocationSlugs = (
+    queryClient.getQueryData<DbLocation[]>(['locations']) ?? []
+  ).map((location) => locationSlug(location.name))
+  const validLocationSlugs = locationSlugs?.filter((slug) =>
+    knownLocationSlugs.includes(slug),
+  )
+
   // Fetch edit permissions if user is logged in
   let editPermissions: Record<string, boolean> = {}
   if (user?.id) {
@@ -79,6 +91,9 @@ export default async function ScheduleProvider({
       <Schedule
         sessionId={sessionId}
         dayIndex={dayIndex}
+        locationSlugs={
+          validLocationSlugs?.length ? validLocationSlugs : undefined
+        }
         editPermissions={editPermissions}
       />
     </HydrationBoundary>

--- a/app/schedule/page.tsx
+++ b/app/schedule/page.tsx
@@ -1,5 +1,6 @@
 import ScheduleKey from './ScheduleKey'
 import ScheduleProvider from './ScheduleProvider'
+import { locationSlug } from './scheduleUtils'
 import { z } from 'zod'
 
 type SearchParams = Promise<{ [key: string]: string | string[] | undefined }>
@@ -11,7 +12,11 @@ export default async function ScheduleDemo({
 }: {
   searchParams: SearchParams
 }) {
-  const { session: sessionIdParam, day: dayIndexParam } = await searchParams
+  const {
+    session: sessionIdParam,
+    day: dayIndexParam,
+    locations: locationsParam,
+  } = await searchParams
 
   const parsedSessionId = sessionIdSchema.safeParse(sessionIdParam)
   const parsedDayIndex = dayIndexSchema.safeParse(dayIndexParam)
@@ -19,12 +24,19 @@ export default async function ScheduleDemo({
     parsedDayIndex.success && [0, 1, 2].includes(parsedDayIndex.data)
       ? parsedDayIndex.data
       : undefined
+  // ?locations=the-clocktower,bayes-hall — slugified so hand-written links are forgiving
+  const locationSlugs = [locationsParam ?? []]
+    .flat()
+    .flatMap((value) => value.split(','))
+    .map(locationSlug)
+    .filter(Boolean)
   return (
     <div className="h-fit w-full bg-dark-500 p-4">
-      <div className="flex w-full flex-col gap-2 overflow-hidden rounded-2xl border border-secondary-300">
+      <div className="mx-auto flex w-fit max-w-full flex-col gap-2 overflow-hidden rounded-2xl border border-secondary-300">
         <ScheduleProvider
           dayIndex={dayIndex}
           sessionId={parsedSessionId.success ? parsedSessionId.data : undefined}
+          locationSlugs={locationSlugs.length > 0 ? locationSlugs : undefined}
         />
         <ScheduleKey />
       </div>

--- a/app/schedule/scheduleUtils.ts
+++ b/app/schedule/scheduleUtils.ts
@@ -36,3 +36,10 @@ export const gCalLinkFromSession = (session: DbFullSession) => {
 export const sessionLink = (sessionId: string) => {
   return `${process.env.NEXT_PUBLIC_SITE_URL}/schedule?session=${sessionId}`
 }
+
+// Locations have no slug column, so shareable ?locations= links key off the name
+export const locationSlug = (locationName: string) =>
+  locationName
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')


### PR DESCRIPTION
Adds a location filter to the schedule so you can link someone straight to the columns you care about — `?locations=the-clocktower,the-gardens`. The param round-trips: picking locations in the UI rewrites the URL, so any filtered view is copy-pasteable.

The filter lives in the header cell left of the location names. Tri-state top row (**Select all** / **Clear all**, with an indeterminate dash when partial), a per-row **only** shortcut on hover, and a slow sky-blue pulse on the cell whenever a filter is active so it's obvious on arrival.

Notes on the non-obvious bits:
- Slugs are matched forgivingly (`?locations=The%20Clocktower` normalizes), and unknown slugs are pruned **server-side** in `ScheduleProvider` — a stale link renders the full schedule instead of a blank grid, with no post-hydration flash.
- Selecting everything collapses to *no* param rather than listing all 12.
- `repeat(0, ...)` is invalid CSS: the browser drops the declaration and keeps the previous track list, so an empty selection was leaving a full-width grid with no columns in it. The template is now built once behind a guard.

Drive-by fixes:
- `globals.css` was missing a semicolon after `--font-mulish`, which swallowed `--animate-coin-pop` into the font stack — that animation had been silently dead.
- Location thumbnails no longer stretch to column width; columns cap at 2x their 180px baseline and the schedule shrink-wraps to its columns instead of filling the page.

## Already verified
Typecheck, eslint and prettier clean. Driven in a browser against local data: deep links (single + multi), forgiving/unknown slugs, tri-state transitions, `only`, per-item vs. select-all vs. clear-all dismissal behavior, empty-state centering (measured — message center matches card center), and that the unfiltered view still fills the page and scrolls horizontally.

## Test plan
- [ ] Eyeball the filtered layout on mobile — I only drove this at desktop width.
- [ ] Decide on two open design questions: vertically centering the filter button would need the whole header to become sticky (~186px) to get a genuinely merged cell; and the day-nav header gets cramped at one or two columns now that the card shrink-wraps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)