### PR TITLE
Make auth guards throw instead of returning booleans [META-399]

### DIFF
--- a/app/actions/db/sessionRsvps.ts
+++ b/app/actions/db/sessionRsvps.ts
@@ -4,7 +4,7 @@ import { adminExportWrapper, currentUserWrapper } from './auth'
 
 import { sessionRsvpsService } from '@/lib/db/sessionRsvps'
 
-import { currentUserHasAuthLevel } from '@/utils/security'
+import { assertAuthLevel } from '@/utils/security'
 
 export const getAllRsvps = sessionRsvpsService.getAllRsvps
 
@@ -40,9 +40,10 @@ export const greenUnRsvpUserFromSession = async ({
   sessionId: string
   userId: string
 }) => {
-  if (!currentUserHasAuthLevel({ authLevel: 'GREEN' })) {
-    throw new Error('Unauthorized user trying to un-RSVP a user')
-  }
+  await assertAuthLevel({
+    authLevel: 'GREEN',
+    message: 'Unauthorized user trying to un-RSVP a user',
+  })
   return sessionRsvpsService.unrsvpUserFromSession({ sessionId, userId })
 }
 export const adminRsvpUserToSession = adminExportWrapper(

--- a/app/actions/db/tickets.ts
+++ b/app/actions/db/tickets.ts
@@ -6,7 +6,7 @@ import { ticketsService } from '@/lib/db/tickets'
 import { usersService } from '@/lib/db/users'
 
 import { TEAM_COLORS } from '@/utils/dbUtils'
-import { authLevelsToRanks, getCurrentUserAuthRank } from '@/utils/security'
+import { assertAuthLevel } from '@/utils/security'
 import { createServiceClient } from '@/utils/supabase/service'
 
 import { DbTicket } from '@/types/database/dbTypeAliases'
@@ -79,7 +79,6 @@ export const signupByTicketCode = async ({
   return { success: true, error: null, ticket: ticket }
 }
 export const volunteerGetAllFullTickets = async () => {
-  if ((await getCurrentUserAuthRank()) < authLevelsToRanks.VOLUNTEER)
-    throw new Error('Unauthorized')
+  await assertAuthLevel({ authLevel: 'VOLUNTEER' })
   return await ticketsService.getAllFullTickets()
 }

--- a/app/actions/db/users.ts
+++ b/app/actions/db/users.ts
@@ -6,7 +6,7 @@ import { playerCardClaimsService } from '@/lib/db/playerCardClaims'
 import { sessionsService } from '@/lib/db/sessions'
 import { usersService } from '@/lib/db/users'
 
-import { authLevelsToRanks, getCurrentUserAuthRank } from '@/utils/security'
+import { assertAuthLevel } from '@/utils/security'
 
 /* Queries */
 export const getCurrentUser = usersService.getCurrentUser
@@ -45,8 +45,7 @@ export const volunteerUpdateUserCheckin = async ({
   userId: string
   checked_in: boolean
 }) => {
-  if ((await getCurrentUserAuthRank()) < authLevelsToRanks.VOLUNTEER)
-    throw new Error('Unauthorized')
+  await assertAuthLevel({ authLevel: 'VOLUNTEER' })
   await usersService.updateUserProfile({ userId, data: { checked_in } })
 }
 export const deleteCurrentUserProfilePicture = async () =>

--- a/utils/security.ts
+++ b/utils/security.ts
@@ -45,20 +45,20 @@ export const getCurrentUserAuthLevel = async (): Promise<AuthLevel> => {
 export const getCurrentUserAuthRank = async (): Promise<number> => {
   return authLevelsToRanks[await getCurrentUserAuthLevel()]
 }
-/** Whether the current user has >= the specified auth level */
-export const currentUserHasAuthLevel = async ({
+/** Throws unless the current user has >= the specified auth level.
+ *
+ * Throw-on-fail rather than boolean-returning on purpose: an un-awaited async
+ * predicate is a truthy Promise, so `if (!hasAuthLevel(...))` silently passes. */
+export const assertAuthLevel = async ({
   authLevel = 'ADMIN',
-}: { authLevel?: AuthLevel } = {}) => {
-  return (await getCurrentUserAuthRank()) >= authLevelsToRanks[authLevel]
-}
-/** Whether the current user has >= the specified auth rank number */
-export const currentUserHasAuthRank = async ({
-  authRank = 3,
-}: { authRank?: number } = {}) => {
-  return (await getCurrentUserAuthRank()) >= authRank
+  message = 'Unauthorized',
+}: { authLevel?: AuthLevel; message?: string } = {}) => {
+  if ((await getCurrentUserAuthRank()) < authLevelsToRanks[authLevel]) {
+    throw new Error(message)
+  }
 }
 /** Whether the provided user profile has >= the specified auth rank number */
-export const profileHasAuthRank = async ({
+export const profileHasAuthRank = ({
   profile,
   authRank = 3,
 }: {


### PR DESCRIPTION
A missing `await` at `app/actions/db/sessionRsvps.ts:43` made `!currentUserHasAuthLevel(...)` test a Promise (always falsy-negated), so `greenUnRsvpUserFromSession` ran unguarded for any caller — including anonymous ones. Rather than just adding the `await`, the async boolean predicates are replaced with a throw-on-fail `assertAuthLevel`, so a forgotten `await` can't silently pass.

**Refactor vs. plain await:** I did the refactor — the blast radius turned out to be 1 call site of `currentUserHasAuthLevel` and 0 of the other two async predicates, so removing the footgun entirely was cheaper than leaving it in place.

## Call-site audit

Every call site of the `utils/security.ts` auth predicates, grepped across all `.ts`/`.tsx`:

| Call site | Predicate | Awaited before? | Action |
|---|---|---|---|
| `app/actions/db/sessionRsvps.ts:43` | `currentUserHasAuthLevel` | ✗ **the bug** | → `await assertAuthLevel({ authLevel: 'GREEN' })` |
| _(none)_ | `currentUserHasAuthRank` | — | zero call sites; removed |
| _(none)_ | `profileHasAuthRank` | — | zero call sites; was needlessly `async` (sync body), now sync |
| `app/schedule/RSVPList.tsx:154` | `profileHasAuthLevel` | ✓ n/a — sync, client-side UI gate | unchanged |
| `app/actions/db/tickets.ts:82` | `getCurrentUserAuthRank` | ✓ | → `assertAuthLevel({ authLevel: 'VOLUNTEER' })` (same semantics) |
| `app/actions/db/users.ts:48` | `getCurrentUserAuthRank` | ✓ | → `assertAuthLevel({ authLevel: 'VOLUNTEER' })` (same semantics) |
| `app/actions/db/sessions.ts:37` | `getCurrentUserAuthRank` | ✓ | unchanged — needs a boolean (falls back to session-host check) |
| `app/team/page.tsx:39` | `getCurrentUserAuthRank` | ✓ | unchanged — needs a boolean (conditional team view) |
| `app/admin/layout.tsx:8` | `redirectIfNotAuthed` | ✓ | unchanged |
| `app/checkin/layout.tsx:10` | `redirectIfNotAuthed` | ✓ | unchanged |

Only one site was actually broken. Behaviour of the two converted `getCurrentUserAuthRank` guards is identical (rank `< VOLUNTEER` → `throw new Error('Unauthorized')`).

## Testing required

The main regression risk is a **false lockout** — a legitimately privileged user now hitting "Unauthorized" where the guard previously passed. Please exercise each guard with a real account:

### `/schedule` — un-RSVP (the fixed guard)
- As a **green-team or admin** user: open a session's RSVP list, click the red un-RSVP button on an attendee. It should still succeed, and someone should get promoted off the waitlist as before.
- As a **regular (orange/purple) logged-in** user: the un-RSVP button should not render at all (that gate is client-side and unchanged).
- Your own RSVP / un-RSVP / waitlist-join flows on `/schedule` should be unaffected — those go through `currentUserWrapper`, not this guard.

### `/checkin` — volunteer guards
- As a **volunteer, green, or admin**: the page should load the ticket list (`volunteerGetAllFullTickets`) and checking a user in should still work (`volunteerUpdateUserCheckin`).
- As a **regular logged-in user**: the layout should still redirect you away, same as before.

### `/admin` and `/team`
- Admin pages should load for admins and redirect for everyone else (unchanged code, but the shared module moved — worth a smoke test).
- `/team?color=orange` as a green/admin user should still show the requested team; as a regular user it should still fall back to your own team.

### Not checkable from the preview deploy
- **Confirming the un-RSVP action now rejects an unauthenticated caller.** Verifying this means POSTing the server action directly (logged out) rather than clicking the UI, since the button never renders for unprivileged users. Easiest check: log out, open `/schedule` in a fresh session, and confirm no privileged un-RSVP path exists; the actual server-side rejection is best confirmed by reading the guard or by replaying the server-action POST from devtools with cookies cleared, which should now return an error instead of silently removing the attendee.
- No local typecheck/lint was run (no `node_modules` on this box) — CI and the preview build are the gate.

## Noticed but out of scope
- `utils/security.ts:84` still defaults `redirectTo` to `/not-authorized` while the route is `/unauthorized` — that's META-406's, untouched here.
- `getCurrentUserAuthRank()` is still an async value used in `<`/`>=` comparisons in `sessions.ts` and `team/page.tsx`; both are correctly awaited today, but an un-awaited Promise comparison would also silently evaluate false. Those two sites genuinely need a boolean, so they weren't converted.
