### PR TITLE
Remove stray 'use server' directives from pages and components [META-400]

### DIFF
--- a/app/campus/page.tsx
+++ b/app/campus/page.tsx
@@ -1,5 +1,3 @@
-'use server'
-
 //import { useState } from 'react'
 import CampusMap /*, { locations, megagameLocations }*/ from './components/CampusMap'
 

--- a/app/cards/page.tsx
+++ b/app/cards/page.tsx
@@ -1,5 +1,3 @@
-'use server'
-
 import { celestialCardsService } from '@/lib/db/celestialCards'
 
 import PlayerCard from '@/components/PlayerCard/PlayerCard'

--- a/app/checkin/layout.tsx
+++ b/app/checkin/layout.tsx
@@ -1,5 +1,3 @@
-'use server'
-
 import { redirectIfNotAuthed } from '@/utils/security'
 
 export default async function CheckinLayout({

--- a/app/checkin/page.tsx
+++ b/app/checkin/page.tsx
@@ -1,5 +1,3 @@
-'use server'
-
 import { volunteerGetAllFullTickets } from '../actions/db/tickets'
 import CheckinTable from './CheckinTable'
 

--- a/components/PickACard/PickACardMetaProvider.tsx
+++ b/components/PickACard/PickACardMetaProvider.tsx
@@ -1,5 +1,3 @@
-'use server'
-
 import PickACard from './PickACardProvider'
 
 import { currentUserLatestUnclaimedVictory } from '@/app/actions/db/users'

--- a/components/PickACard/PickACardProvider.tsx
+++ b/components/PickACard/PickACardProvider.tsx
@@ -1,5 +1,3 @@
-'use server'
-
 import CardPicker from './CardPicker'
 
 import { sessionsService } from '@/lib/db/sessions'

--- a/components/sections/home/Highlights.tsx
+++ b/components/sections/home/Highlights.tsx
@@ -1,5 +1,3 @@
-'use server'
-
 import { MoonIcon } from 'lucide-react'
 import Link from 'next/link'
 
@@ -9,10 +7,11 @@ import { Separator } from '@/components/ui/separator'
 import { getSessionById } from '@/app/actions/db/sessions'
 
 const nightMarketSessionId = 'e0dfc2cf-b2b0-46c4-8a27-dc14d551be17'
-const nightMarketSession = await getSessionById({
-  sessionId: nightMarketSessionId,
-})
+
 export default async function Highlights() {
+  const nightMarketSession = await getSessionById({
+    sessionId: nightMarketSessionId,
+  })
   return (
     <section className="flex flex-col rounded-xl border border-border-accent p-4">
       <div className="mb-4 self-center text-2xl font-bold text-secondary-200">


### PR DESCRIPTION
Seven server-component modules started with `'use server'`, which marks the **whole module** as a server-actions module and compiles every export into a POST-callable endpoint with a stable action id — an invocation path that bypasses layouts, and `/checkin`'s volunteer gate lives in its layout. Removing the directive restores them to ordinary server components (the App Router default).

- Directive removed from `app/checkin/page.tsx`, `app/checkin/layout.tsx`, `app/campus/page.tsx`, `app/cards/page.tsx`, `components/PickACard/PickACardMetaProvider.tsx`, `components/PickACard/PickACardProvider.tsx`, `components/sections/home/Highlights.tsx`.
- Verified before deleting: each of the seven has exactly one export, an async default React component, and every one is rendered as JSX from a server parent (`app/page.tsx`, `app/layout.tsx`, `PickACardMetaProvider`). None is imported by a client component or invoked as an action, so no call site changes.
- `Highlights.tsx`: also moved the module-scope `await getSessionById(...)` inside `Highlights()`. See the note below.
- Repo-wide grep for `use server` turned up 21 hits — the seven above plus 14 legitimate ones, all in `app/actions/**` or a route-local `actions.ts` (`app/campus/components/actions.ts`, `app/schedule/actions.ts`, `app/admin/tools/{issue-tickets,coupons}/actions.ts`). Nothing else to clean up; the issue's list of seven was complete and accurate.

## Overlap with META-406 — expect a conflict

META-406 is moving the same `Highlights.tsx` fetch on a parallel branch. I moved it here too because this PR cannot be reviewed without it: with the directive gone the module-scope `await` is the one line whose compilation genuinely changes, and a red preview build would block review of the other six files. **Whoever merges second should expect a conflict in `components/sections/home/Highlights.tsx` and take META-406's version** — this PR does only the mechanical `await`-into-component move, none of the rest of META-406's work.

One correction to the issue body: it claims the directive is "what makes the module-scope top-level `await` possible." That looks wrong — `module: "esnext"` + `target: "ES2017"` in `tsconfig.json` already permit top-level await, and Next enables webpack's `topLevelAwait` experiment regardless of the directive. The move is still worth doing (module-scope await fetches once at module init and freezes the result for the process lifetime), but it is probably not load-bearing for the build.

## Testing required

This change alters how these modules compile, so **"the page renders at all" is the real test** — there is no subtle visual diff to hunt for. On the preview deploy:

- `/campus` renders, map and sudoku overlays present.
- `/cards` renders the full card grid.
- Home page renders, and the **Highlight Events** section shows the Night Market block with a working **Add to Calendar** button (this is the `Highlights.tsx` fetch — confirm it did not silently become `null`).
- Navigate around a bit to confirm the root layout still renders; `PickACardMetaProvider` sits in `app/layout.tsx`, so a failure there takes down every page.

### Needs a volunteer (or higher) account

- `/checkin` loads and the check-in table populates with tickets.
- Confirm a **logged-out** hit on `/checkin` still redirects — the gate is in `app/checkin/layout.tsx`, which this PR touched.
- Pick-A-Card flow: with an account holding an unclaimed victory from the last 5 days, confirm the card picker still appears and a card can be claimed.
