### PR TITLE
Fix RSVP/waitlist data integrity: team filter, capacity, displayed counts [META-404]

### DIFF
--- a/app/actions/db/sessionRsvps.ts
+++ b/app/actions/db/sessionRsvps.ts
@@ -12,7 +12,7 @@ export const getUserRsvps = sessionRsvpsService.getUserRsvps
 
 export const getAllSessionRsvpCounts =
   sessionRsvpsService.getAllSessionRsvpCounts
-export const getSingleSessionRsvps = sessionRsvpsService.getSingleSessionRsvps
+export const getSingleSessionRsvps = sessionRsvpsService.getSessionRsvps
 export const getCurrentUserRsvps = async () => {
   try {
     return await currentUserWrapper(sessionRsvpsService.getUserRsvps)({})

--- a/app/schedule/RSVPList.tsx
+++ b/app/schedule/RSVPList.tsx
@@ -27,6 +27,7 @@ export const AttendanceDisplay = ({
   const teamCap = session.max_capacity
     ? Math.floor(session.max_capacity / 2)
     : undefined
+  const goingRsvps = session.rsvps.filter((rsvp) => !rsvp.on_waitlist)
   const standardRsvpDisplay = () => {
     if (!userLoggedIn) {
       return (
@@ -43,14 +44,14 @@ export const AttendanceDisplay = ({
     return (
       <span>
         {session.max_capacity
-          ? `${session.rsvps.length} / ${session.max_capacity}`
-          : `${session.rsvps.length}`}
+          ? `${goingRsvps.length} / ${session.max_capacity}`
+          : `${goingRsvps.length}`}
       </span>
     )
   }
   const megagameRsvpDisplay = () => {
-    // For megagames, we need the team breakdown from client-side RSVP data (once we implement teams)
-    const teamCounts = countRsvpsByTeamColor(session.rsvps)
+    // Team breakdown counts only confirmed attendees, not the waitlist
+    const teamCounts = countRsvpsByTeamColor(goingRsvps)
     return (
       <div className="flex items-center gap-1 font-sans text-xs">
         <div className="rounded-md bg-gray-200 px-1 py-0.5">

--- a/lib/db/sessionRsvps.ts
+++ b/lib/db/sessionRsvps.ts
@@ -1,5 +1,3 @@
-import { sessionsService } from './sessions'
-
 import { usersService } from '@/lib/db/users'
 
 import { createServiceClient } from '@/utils/supabase/service'
@@ -78,17 +76,6 @@ export const sessionRsvpsService = {
     }
     return data satisfies DbFullSessionRsvp[]
   },
-  getSingleSessionRsvps: async ({ sessionId }: { sessionId: string }) => {
-    const supabase = createServiceClient()
-    const { data, error } = await supabase
-      .from('session_rsvps')
-      .select(sessionRsvpsSelectIncludes)
-      .eq('session_id', sessionId)
-    if (error) {
-      throw new Error(error.message)
-    }
-    return data satisfies DbFullSessionRsvp[]
-  },
   /**
    * Pop earliest waitlisted users, optionally filtered by team, up to `limit`.
    * Returns array of userIds popped. No-op (empty array) if none.
@@ -104,7 +91,7 @@ export const sessionRsvpsService = {
   }) => {
     const supabase = createServiceClient()
 
-    let query = supabase
+    const { data, error } = await supabase
       .from('session_rsvps')
       .select(
         'user_id, user:profiles!session_rsvps_user_id_fkey ( team ), created_at',
@@ -112,19 +99,19 @@ export const sessionRsvpsService = {
       .eq('session_id', sessionId)
       .eq('on_waitlist', true)
       .order('created_at', { ascending: true })
-      .limit(limit)
-    if (team) {
-      // Filter by team of the joined profile
-      query = query.eq('user.team', team)
-    }
-    const { data, error } = await query
     if (error) {
       throw new Error(error.message)
     }
-    if (!data || data.length === 0) {
+    // Filter by team in JS (as countGoingForTeam does): a PostgREST .eq() on an
+    // embedded resource nulls the embed on non-matching rows instead of
+    // filtering parent rows, so `limit` must also apply after the filter.
+    const candidates = (
+      team ? data.filter((row) => row.user.team === team) : data
+    ).slice(0, limit)
+    if (candidates.length === 0) {
       return [] as string[]
     }
-    const userIds = data.map((row) => row.user_id)
+    const userIds = candidates.map((row) => row.user_id)
     const { error: updateError } = await supabase
       .from('session_rsvps')
       .update({ on_waitlist: false })
@@ -240,7 +227,13 @@ export const sessionRsvpsService = {
     return await sessionRsvpsService.rsvpUserToSession({ sessionId, userId })
   },
 
-  /** RSVP a user to a session. For megagame sessions, enforce per-team caps (half of max). Put on waitlist when team side is full. No-op if already RSVPd. */
+  /**
+   * RSVP a user to a session. For megagame sessions, enforce per-team caps (half of max). Put on waitlist when team side is full. No-op if already RSVPd.
+   *
+   * Known limitation (META-404): the capacity check is read-then-insert with no
+   * DB-side guard, so two concurrent RSVPs can both take the last seat. A real
+   * fix needs the count-and-insert pushed into Postgres (function or trigger).
+   */
   rsvpUserToSession: async ({
     sessionId,
     userId,
@@ -261,8 +254,13 @@ export const sessionRsvpsService = {
 
     let on_waitlist = false
     if (!megagame) {
-      const sessionFull = await sessionsService.sessionIsFull({ sessionId })
-      on_waitlist = sessionFull
+      // "Full" means going (non-waitlisted) count >= capacity — the same
+      // predicate the promotion paths use, so waitlisting only happens when
+      // there is genuinely no open seat.
+      if (max_capacity && max_capacity > 0) {
+        const goingCount = await countGoing({ sessionId })
+        on_waitlist = goingCount >= max_capacity
+      }
     } else {
       const userTeam = (
         await usersService.getUserPublicProfileById({

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -64,23 +64,6 @@ export const sessionsService = {
     }
     return data satisfies DbFullSession | null
   },
-  /** Check if a session is full */
-  sessionIsFull: async ({ sessionId }: { sessionId: string }) => {
-    const supabase = createServiceClient()
-    const { data: session, error: sessionError } = await supabase
-      .from('sessions')
-      .select('max_capacity, session_rsvps(count)')
-      .eq('id', sessionId)
-      .single()
-    if (sessionError) {
-      throw new Error(sessionError.message)
-    }
-    return (
-      session.max_capacity !== null &&
-      (session.session_rsvps[0].count || 0) >= session.max_capacity
-    )
-  },
-
   getAllSessions: async () => {
     const supabase = createServiceClient()
     const { data, error } = await supabase


### PR DESCRIPTION
Fixes three of the four RSVP/waitlist data-integrity bugs from META-404 (team-blind waitlist promotion, two conflicting definitions of "full", and over-capacity displayed counts), and documents the fourth (the capacity race) as an explicit follow-up.

## Per-bug

- **(1) Waitlist team filter** — `popSessionWaitlist` no longer uses `.eq('user.team', team)` on the embedded profile (which nulls the embed instead of filtering parent rows). It now fetches the session's waitlisted RSVPs ordered by `created_at` and filters by team in JS — the same pattern the already-correct `countGoingForTeam` uses — with `limit` applied **after** the filter. This fixes cross-team promotions in both `unrsvpUserFromSession` and the `repairSessionWaitlists` cron. *Judgment call:* I verified the FK name (`session_rsvps_user_id_fkey` in `supabase/migrations/20250901_init.sql`), so the `!inner` hint form was available, but I chose the JS filter because it mirrors the known-working code and can't be wrong about PostgREST semantics we can't test here. Waitlists are small, so fetching them un-limited is cheap.
- **(2) Two definitions of "full"** — `rsvpUserToSession` now computes fullness as `countGoing >= max_capacity` (the `on_waitlist = false` predicate every promotion path uses). `sessionIsFull` — which counted waitlisted rows toward capacity — is deleted; it had no other callers. Minor behavior note: a `max_capacity` of 0 is now treated as "no limit" (matching how the rest of the file treats it) where the old code waitlisted everyone. Residual edge (unchanged by this PR): if an admin raises `max_capacity` while a waitlist exists, a new RSVP can still be seated ahead of waitlisted people until the repair cron runs.
- **(3) Read-then-insert race** — **scoped down to a follow-up**, documented in a comment on `rsvpUserToSession`. Reasoning: the PK `(session_id, user_id)` already prevents duplicate rows, so the race is purely capacity oversell of the last seat(s). The issue's suggested partial unique/exclusion constraint **cannot express** "count < max_capacity" (Postgres constraints don't do aggregates); the real fix is a `SECURITY DEFINER` function or trigger doing lock-count-insert, which would also have to absorb the megagame per-team-cap and green/unassigned-rejection logic. Landing that migration plus an `.rpc()` rewrite with no way to run or typecheck anything here is exactly the half-implemented-migration risk the issue warns about, so I fixed 1/2/4 properly and left 3 for a dedicated change. Note fix (2) removes the *systematic* overselling (waitlisted rows counting toward capacity); what remains is the genuine concurrent-click window.
- **(4) Displayed counts** — `AttendanceDisplay` now filters `!on_waitlist` once and uses that list for both the standard chip (`going / max`) and the megagame per-team chip. `countRsvpsByTeamColor` itself is unchanged (it stays a generic counter; it's fed the pre-filtered list — its only call site).

## Also

- Deleted `getSingleSessionRsvps` (byte-identical duplicate of `getSessionRsvps`); the server action keeps its exported name, now pointing at `getSessionRsvps`. No other consumers existed.
- Did **not** do a broader pass on the file's general drift — kept the diff to the four bugs.

## Testing required

None of this is fully visible from a page load; it needs deliberate poking on the preview.

**Single account, browser (preview):**
1. Open `/schedule` while logged in. For a session with waitlisted people, the chip count must match the tooltip's "Going (n/m)" and must never exceed capacity (previously a 20-cap session with 3 waitlisted showed "23 / 20").
2. RSVP to a session that has waitlisted people **but** open "going" seats (the drift case): you should now be admitted as going, not waitlisted. RSVP to a genuinely full session: you should be waitlisted.
3. Un-RSVP from a full session you were "going" to and confirm the **earliest-created** waitlisted person is promoted (check the tooltip lists before/after).

**Needs multiple accounts / seeded data:**
- **Megagame team caps** — the core of bug 1 — realistically needs a scripted check against a DB with team data, not a browser: seed a megagame session at team cap with a mixed-team waitlist, un-RSVP an orange "going" player, and verify only the earliest **orange** waitlisted player is promoted (before this PR, the earliest waitlisted player of *any* team was). Repeat for purple. Also verify each team's going count never exceeds `floor(max_capacity / 2)` after a sequence of RSVPs/un-RSVPs.
- **Repair cron** — `repairSessionWaitlists` only runs nightly, so its behavior can only be checked by invoking it manually (admin action / direct call) against a session seeded with open slots + a mixed-team waitlist, and confirming promotions respect team and `created_at` order.

**Manual steps:** none — no migration in this PR. The follow-up for bug (3) will require one (Postgres function or trigger) that must be applied by hand.

[META-404]

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PPepDLatLzfSBuBxxsuiU