### PR TITLE
Allowlist self-editable profile fields server-side [META-398]

### DIFF
--- a/app/actions/db/users.ts
+++ b/app/actions/db/users.ts
@@ -5,6 +5,10 @@ import { adminExportWrapper, currentUserWrapper } from './auth'
 import { playerCardClaimsService } from '@/lib/db/playerCardClaims'
 import { sessionsService } from '@/lib/db/sessions'
 import { usersService } from '@/lib/db/users'
+import {
+  SelfEditableProfileData,
+  selfEditableProfileSchema,
+} from '@/lib/schemas/profile'
 
 import { authLevelsToRanks, getCurrentUserAuthRank } from '@/utils/security'
 
@@ -34,8 +38,23 @@ export const getUsersIdsByTeam = usersService.getUsersIdsByTeam
 export const getAllUsersIds = usersService.getAllUsersIds
 export const getPublicProfilesByTeam = usersService.getPublicProfilesByTeam
 /* Mutations */
+/** Self-service profile update. The payload is parsed against an allowlist before it
+ * reaches the DB: forwarding a raw `TablesUpdate<'profiles'>` here would let any
+ * logged-in user set their own `is_admin`, `team`, `checked_in` or `player_id`. */
 export const updateCurrentUserProfile = currentUserWrapper(
-  usersService.updateUserProfile,
+  async ({
+    userId,
+    data,
+  }: {
+    userId: string
+    data: SelfEditableProfileData
+  }) => {
+    const allowedData = selfEditableProfileSchema.parse(data)
+    if (Object.keys(allowedData).length === 0) {
+      throw new Error('No self-editable profile fields supplied')
+    }
+    return usersService.updateUserProfile({ userId, data: allowedData })
+  },
 )
 /** Updates a user's checked in status if the current user has any admin privileges */
 export const volunteerUpdateUserCheckin = async ({

--- a/lib/db/users.ts
+++ b/lib/db/users.ts
@@ -155,7 +155,8 @@ export const usersService = {
     }
     return data satisfies DbFullProfile[]
   },
-  /** Update a user's profile */
+  /** Update a user's profile. Accepts any column, so callers reachable from the
+   * client must allowlist `data` first (see `selfEditableProfileSchema`). */
   updateUserProfile: async ({
     userId,
     data,

--- a/lib/schemas/profile.ts
+++ b/lib/schemas/profile.ts
@@ -25,6 +25,23 @@ export const profileFormSchema = z.object({
 
 export type ProfileFormData = z.infer<typeof profileFormSchema>
 
+/**
+ * The complete set of profile columns a user may write to their *own* profile.
+ * Anything outside this list (is_admin, team, checked_in, player_id, email,
+ * volunteer, homepage_order, celestial_card_id) is stripped server-side, so a new
+ * self-service field must be added here as well as to the form schema above.
+ */
+export const selfEditableProfileSchema = profileFormSchema
+  .extend({
+    // Written outside the form: picture upload and the "stop prompting me" button.
+    profile_pictures_url: z.string().nullable(),
+    dismissed_info_request: z.boolean(),
+  })
+  .partial()
+
+/** Shape accepted by `updateCurrentUserProfile` (pre-parse). */
+export type SelfEditableProfileData = z.input<typeof selfEditableProfileSchema>
+
 export const initialProfileFormData: ProfileFormData = {
   first_name: '',
   last_name: '',


### PR DESCRIPTION
Any logged-in user could POST the profile-update server action with `{ data: { is_admin: true } }` and become an admin, because `updateCurrentUserProfile` forwarded the caller's raw `TablesUpdate<'profiles'>` bag straight to the DB. The action now parses `data` against a server-side allowlist before it reaches `usersService.updateUserProfile`.

- Added `selfEditableProfileSchema` in `lib/schemas/profile.ts` — `profileFormSchema` plus the two fields the profile UI writes outside the form, all `.partial()` so single-field updates still work.
- `updateCurrentUserProfile` (`app/actions/db/users.ts`) now `.parse()`s its payload and throws if nothing allowlisted survives, instead of issuing an empty UPDATE.
- Left `adminUpdateUserProfile` on the full `DbProfileUpdate` — admins legitimately set `is_admin` / `team` / `homepage_order`; it is gated by `adminExportWrapper`.
- Comment on `usersService.updateUserProfile` noting it accepts any column and client-reachable callers must allowlist first.

## Fields now in the allowlist

Everything below is writable by a user on their own profile; **anything not listed is silently dropped**. Eyeball this list for omissions — a missing field means that input silently stops saving.

| Field | Written by |
| --- | --- |
| `first_name` | /profile edit form, complete-your-profile modal |
| `last_name` | /profile edit form, modal |
| `pronouns` | /profile edit form |
| `bio` | /profile edit form, modal |
| `discord_handle` | /profile edit form |
| `site_name` | /profile edit form |
| `site_url` | /profile edit form |
| `site_name_2` | admin editor only (in schema, no field on /profile) |
| `site_url_2` | admin editor only (in schema, no field on /profile) |
| `opted_in_to_homepage_display` | /profile edit form, modal |
| `minor` (the "18+?" radio) | /profile edit form, modal |
| `bringing_kids` | /profile edit form, modal |
| `profile_pictures_url` | Upload Photo button |
| `dismissed_info_request` | "Stop prompting me for this" button |

Explicitly **not** self-writable: `is_admin`, `team`, `checked_in`, `volunteer`, `player_id`, `email`, `homepage_order`, `celestial_card_id`, `id`.

## Testing required

### 1. Every profile field still persists (regression check — the main risk)

On the preview deploy, logged in as any attendee account:

1. Go to `/profile`, click the pencil icon to enter edit mode.
2. Change **every** field to a new, distinguishable value: First name, Last name, Pronouns, Bio, Discord Handle, Website name, Website URL, plus all three radio groups (Show on Homepage, 18+?, Bringing Kids).
3. Save Changes → expect the "Profile updated successfully!" toast.
4. **Hard-reload the page.** Every value must still be there. A field that reverts to its old value is a regression: it means that column is missing from the allowlist.
5. Re-enter edit mode, **clear** a text field (e.g. Bio) and save, reload — it should now be empty, not restored.
6. Flip each radio group to its other value and repeat 3–4.

Then the two non-form writes:

7. **Upload Photo** with a small image → toast, avatar updates, reload → new picture persists. Then **Remove Photo** → reload → still removed.
8. The "Complete Your Profile" modal (appears on `/profile` for an account with an incomplete profile — blank first name / null homepage-display / null minor / null bringing_kids). Click **"Stop prompting me for this"** → toast "You won't be prompted again", reload `/profile` → the modal must not reappear. Also test its **Save Profile** button on a separate incomplete account: the name/bio/radio values it collects must persist.

Correct = every value survives a reload. Regression = any value silently reverts, or a save that used to succeed now shows "Failed to update profile".

### 2. The escalation is actually blocked

Server Actions aren't callable by URL, so the repro is to replay a real profile-save request with an edited payload. Logged in as a **non-admin** attendee on the preview:

1. Open devtools → Network, enter edit mode on `/profile`, change your bio, click **Save Changes**.
2. Find the POST to `/profile` with a `Next-Action` request header. Right-click → **Copy as fetch** (or Copy as cURL).
3. Paste it into the console, and edit the request **body** so the profile object is `{"is_admin":true}` (replacing the bio/name payload; keep the `Next-Action` header and multipart/text framing intact).
4. Run it.

Expected **after** this PR: the request fails — the action throws `No self-editable profile fields supplied` (the `is_admin` key is stripped, leaving an empty update), surfacing as a 500 / server-action error. Then reload `/profile` and confirm you are still not an admin: `/admin` must still be inaccessible.

Repeat with `{"team":"orange"}`, `{"checked_in":true}`, `{"player_id":1}` — same rejection.

Mixed payload check: `{"bio":"hello","is_admin":true}` should **succeed** and set the bio, but must **not** set `is_admin`. Confirm via `/admin` still being denied.

Regression signal: any of the above succeeding in granting admin/team/checkin means the allowlist isn't being applied.

### Cannot be checked from a preview deploy

- **Admin editor is unchanged but should get a smoke test on an admin account** — `/admin/tools/user-profile`: look a user up, Edit Profile, change name/bio/websites/radios, Save, reload; also Upload/Remove photo and Set Password. This PR does not touch `adminUpdateUserProfile`, but it shares `profileFormSchema`, which I extended. Needs admin credentials.
- **`/admin/tools/user-teams`** (bulk team assignment) uses `adminUpdateUserProfile` and must still work — team is deliberately *not* in the self-editable allowlist. Needs admin credentials.
- **Confirming no existing account was mid-flight harmed** — nothing here is a migration, but if anyone already exploited this on prod, `is_admin` / `team` on real rows should be audited against the intended admin list. Prod data, not previewable.

## Noticed but out of scope

- `signupByTicketCode` (`app/actions/db/tickets.ts`) is an unauthenticated action that, for an email matching an existing account with no ticket, re-rolls that account's `team` to a random colour. Not an update-bag bug, but an unauthenticated write to someone else's profile.
- `app/actions/db/users.ts:volunteerUpdateUserCheckin` lets any VOLUNTEER-rank user set `checked_in` on any user — appears intentional, flagging only because it is the other write path to that column.
- `/api/queries/**` auth is META-397 (parallel branch).
