### PR TITLE
Stop returning stack traces and raw DB errors from API routes [META-408]

### DIFF
--- a/app/api/confirm-payment/route.ts
+++ b/app/api/confirm-payment/route.ts
@@ -4,6 +4,7 @@ import { stripe } from '../../../lib/stripe'
 import { NextRequest, NextResponse } from 'next/server'
 import { ZodError } from 'zod'
 
+import { apiError } from '@/lib/apiError'
 import { ticketsService } from '@/lib/db/tickets'
 import { sendTicketConfirmationEmail } from '@/lib/email'
 
@@ -138,8 +139,6 @@ export async function POST(request: NextRequest) {
         'Payment successful! Your ticket has been purchased. Check your email for confirmation.',
     })
   } catch (error) {
-    console.error('Error in confirm-payment:', error)
-
     // Handle Zod validation errors
     if (error instanceof ZodError) {
       return NextResponse.json(
@@ -151,12 +150,6 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    return NextResponse.json(
-      {
-        success: false,
-        error: error instanceof Error ? error.message : 'Internal server error',
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Payment confirmation failed')
   }
 }

--- a/app/api/create-payment-intent/route.ts
+++ b/app/api/create-payment-intent/route.ts
@@ -4,6 +4,7 @@ import { createPaymentIntent } from '../../../lib/stripe'
 import { NextRequest, NextResponse } from 'next/server'
 import { ZodError } from 'zod'
 
+import { apiError } from '@/lib/apiError'
 import { couponsService } from '@/lib/db/coupons'
 
 import { ticketTypeDetails, usdSlidingScaleMinimum } from '@/config/tickets'
@@ -88,11 +89,7 @@ export async function POST(request: NextRequest) {
       clientSecret = secret
       paymentIntentId = intentId
     } catch (error) {
-      console.error('Error creating payment intent:', error)
-      return NextResponse.json(
-        { error: `Failed to create payment intent: ${error}` },
-        { status: 500 },
-      )
+      return apiError(error, 'Failed to create payment intent')
     }
     if (coupon) {
       couponsService.update({
@@ -116,8 +113,6 @@ export async function POST(request: NextRequest) {
         : null,
     })
   } catch (error) {
-    console.error('Error in create-payment-intent:', error)
-
     // Handle Zod validation errors
     if (error instanceof ZodError) {
       return NextResponse.json(
@@ -128,12 +123,6 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    return NextResponse.json(
-      {
-        error: 'Internal server error',
-        details: error instanceof Error ? error.message : 'Unknown error',
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Internal server error')
   }
 }

--- a/app/api/cron/repair-waitlists/route.ts
+++ b/app/api/cron/repair-waitlists/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
 import { sessionRsvpsService } from '@/lib/db/sessionRsvps'
 
 export async function POST(request: NextRequest) {
@@ -35,13 +36,6 @@ export async function POST(request: NextRequest) {
       })),
     })
   } catch (error) {
-    console.error('Waitlist repair cron job failed:', error)
-    return NextResponse.json(
-      {
-        error: 'Failed to repair waitlists',
-        message: error instanceof Error ? error.message : 'Unknown error',
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to repair waitlists')
   }
 }

--- a/app/api/queries/locations/route.ts
+++ b/app/api/queries/locations/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import { getAllLocations } from '@/app/actions/db/locations'
 
 import { DbLocation } from '@/types/database/dbTypeAliases'
@@ -11,21 +13,6 @@ export async function GET() {
 
     return NextResponse.json(locations satisfies ApiAllLocationsResponse)
   } catch (error) {
-    console.error('Error fetching locations:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch locations',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch locations')
   }
 }

--- a/app/api/queries/megagame_locations/route.ts
+++ b/app/api/queries/megagame_locations/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import { getAllMegagameLocations } from '@/app/actions/db/locations'
 
 import { DbMegagameLocation } from '@/types/database/dbTypeAliases'
@@ -13,21 +15,6 @@ export async function GET() {
       locations satisfies ApiAllMegagameLocationsResponse,
     )
   } catch (error) {
-    console.error('Error fetching megagame locations:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch megagame locations',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch megagame locations')
   }
 }

--- a/app/api/queries/profiles/[userId]/route.ts
+++ b/app/api/queries/profiles/[userId]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import { createClient } from '@/utils/supabase/server'
 
 import {
@@ -40,21 +42,6 @@ export async function GET(
 
     return NextResponse.json(profile satisfies ApiUserFullProfileResponse)
   } catch (error) {
-    console.error('Error fetching user profile:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch profile',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch profile')
   }
 }

--- a/app/api/queries/profiles/current/route.ts
+++ b/app/api/queries/profiles/current/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import { getCurrentUserFullProfile } from '@/app/actions/db/users'
 
 import { DbFullProfile } from '@/types/database/dbTypeAliases'
@@ -14,21 +16,6 @@ export async function GET() {
       profile satisfies ApiCurrentUserFullProfileResponse,
     )
   } catch (error) {
-    console.error('Error fetching current user profile:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch profile',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch profile')
   }
 }

--- a/app/api/queries/profiles/public/[userId]/route.ts
+++ b/app/api/queries/profiles/public/[userId]/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import { getUserPublicProfileById } from '@/app/actions/db/users'
 
 import { DbPublicProfile } from '@/types/database/dbTypeAliases'
@@ -26,21 +28,6 @@ export async function GET(
 
     return response
   } catch (error) {
-    console.error('Error fetching user profile:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch profile',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch profile')
   }
 }

--- a/app/api/queries/profiles/public/route.ts
+++ b/app/api/queries/profiles/public/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import {
   getAllUserPublicProfiles,
   getUsersPublicProfiles,
@@ -24,22 +26,7 @@ export async function GET() {
 
     return response
   } catch (error) {
-    console.error('Error fetching profiles:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch profiles',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch profiles')
   }
 }
 
@@ -61,21 +48,6 @@ export async function POST(request: NextRequest) {
 
     return response
   } catch (error) {
-    console.error('Error fetching profiles:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch profiles',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch profiles')
   }
 }

--- a/app/api/queries/profiles/route.ts
+++ b/app/api/queries/profiles/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import {
   adminGetAllFullProfiles,
   adminGetUsersFullProfiles,
@@ -14,22 +16,7 @@ export async function GET() {
 
     return NextResponse.json(profiles satisfies ApiAllFullProfilesResponse)
   } catch (error) {
-    console.error('Error fetching profiles:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch profiles',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch profiles')
   }
 }
 
@@ -41,21 +28,6 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json(profiles satisfies ApiUsersFullProfilesResponse)
   } catch (error) {
-    console.error('Error fetching profiles:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch profiles',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch profiles')
   }
 }

--- a/app/api/queries/rsvps/[userId]/route.ts
+++ b/app/api/queries/rsvps/[userId]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import { getUserRsvps } from '@/app/actions/db/sessionRsvps'
 
 import { DbSessionRsvp } from '@/types/database/dbTypeAliases'
@@ -17,21 +19,6 @@ export async function GET(
 
     return NextResponse.json(rsvps satisfies ApiUserRsvpsResponse)
   } catch (error) {
-    console.error('Error fetching user RSVPs:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch RSVPs',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch RSVPs')
   }
 }

--- a/app/api/queries/rsvps/current/route.ts
+++ b/app/api/queries/rsvps/current/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import { getCurrentUserRsvps } from '@/app/actions/db/sessionRsvps'
 
 import { DbSessionRsvp } from '@/types/database/dbTypeAliases'
@@ -11,21 +13,6 @@ export async function GET() {
 
     return NextResponse.json(rsvps satisfies ApiCurrentUserRsvpsResponse)
   } catch (error) {
-    console.error('Error fetching current user RSVPs:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch RSVPs',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch RSVPs')
   }
 }

--- a/app/api/queries/rsvps/route.ts
+++ b/app/api/queries/rsvps/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import { getAllRsvps } from '@/app/actions/db/sessionRsvps'
 
 import { DbFullSessionRsvp } from '@/types/database/dbTypeAliases'
@@ -11,21 +13,6 @@ export async function GET() {
 
     return NextResponse.json(rsvps satisfies ApiRsvpsResponse)
   } catch (error) {
-    console.error('Error fetching RSVPs:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch RSVPs',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch RSVPs')
   }
 }

--- a/app/api/queries/session-bookmarks/[userId]/route.ts
+++ b/app/api/queries/session-bookmarks/[userId]/route.ts
@@ -1,5 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import { getUserSessionBookmarks } from '@/app/actions/db/sessionBookmarks'
 
 import { DbSessionBookmark } from '@/types/database/dbTypeAliases'
@@ -17,21 +19,6 @@ export async function GET(
       bookmarks satisfies ApiUserSessionBookmarksResponse,
     )
   } catch (error) {
-    console.error('Error fetching user session bookmarks:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch session bookmarks',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch session bookmarks')
   }
 }

--- a/app/api/queries/session-bookmarks/current/route.ts
+++ b/app/api/queries/session-bookmarks/current/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import { currentUserGetSessionBookmarks } from '@/app/actions/db/sessionBookmarks'
 
 import { DbSessionBookmark } from '@/types/database/dbTypeAliases'
@@ -13,21 +15,6 @@ export async function GET() {
       bookmarks satisfies ApiCurrentUserSessionBookmarksResponse,
     )
   } catch (error) {
-    console.error('Error fetching current user session bookmarks:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch session bookmarks',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch session bookmarks')
   }
 }

--- a/app/api/queries/session-bookmarks/route.ts
+++ b/app/api/queries/session-bookmarks/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import { getAllSessionBookmarks } from '@/app/actions/db/sessionBookmarks'
 
 import { DbSessionBookmark } from '@/types/database/dbTypeAliases'
@@ -12,21 +14,6 @@ export async function GET() {
 
     return NextResponse.json(bookmarks satisfies ApiAllSessionBookmarksResponse)
   } catch (error) {
-    console.error('Error fetching all session bookmarks:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch all session bookmarks',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch all session bookmarks')
   }
 }

--- a/app/api/queries/sessions/[id]/ics/route.ts
+++ b/app/api/queries/sessions/[id]/ics/route.ts
@@ -1,4 +1,6 @@
-import { NextRequest, NextResponse } from 'next/server'
+import { NextRequest } from 'next/server'
+
+import { apiError } from '@/lib/apiError'
 
 import { getSessionById } from '@/app/actions/db/sessions'
 import {
@@ -42,22 +44,7 @@ END:VCALENDAR`
       },
     })
   } catch (error) {
-    console.error('Error getting calendar event for session:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to get calendar event for session',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to get calendar event for session')
   }
 }
 

--- a/app/api/queries/sessions/[id]/route.ts
+++ b/app/api/queries/sessions/[id]/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import { getSessionById } from '@/app/actions/db/sessions'
 
 import { DbFullSession } from '@/types/database/dbTypeAliases'
@@ -14,21 +16,6 @@ export async function GET(
 
     return NextResponse.json(session satisfies ApiSessionResponse)
   } catch (error) {
-    console.error('Error fetching session:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch session',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch session')
   }
 }

--- a/app/api/queries/sessions/route.ts
+++ b/app/api/queries/sessions/route.ts
@@ -1,5 +1,7 @@
 import { NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/apiError'
+
 import { getAllSessions } from '@/app/actions/db/sessions'
 
 import { DbFullSession } from '@/types/database/dbTypeAliases'
@@ -11,21 +13,6 @@ export async function GET() {
 
     return NextResponse.json(sessions satisfies ApiAllSessionsResponse)
   } catch (error) {
-    console.error('Error fetching sessions:', error)
-
-    // Return more detailed error information
-    const errorMessage =
-      error instanceof Error ? error.message : 'Unknown error'
-    const errorDetails = error instanceof Error ? error.stack : undefined
-
-    return NextResponse.json(
-      {
-        error: 'Failed to fetch sessions',
-        message: errorMessage,
-        details: errorDetails,
-        timestamp: new Date().toISOString(),
-      },
-      { status: 500 },
-    )
+    return apiError(error, 'Failed to fetch sessions')
   }
 }

--- a/hooks/schedule/queries.ts
+++ b/hooks/schedule/queries.ts
@@ -19,7 +19,8 @@ const handleApiError = async (
   let errorDetails = defaultMessage
   try {
     const errorData = await response.json()
-    errorDetails = errorData.message || errorData.error || errorDetails
+    errorDetails = errorData.error || errorDetails
+    // Only populated outside production; see lib/apiError
     if (errorData.details) {
       console.error('API Error Details:', errorData.details)
     }

--- a/lib/apiError.ts
+++ b/lib/apiError.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server'
+
+/**
+ * Standard 500 response for API routes.
+ *
+ * Everything here runs through the service-role Supabase client, so raw errors
+ * carry table/column/constraint names and stacks carry absolute server paths.
+ * Only `publicMessage` crosses the wire; the real error is logged server-side,
+ * and `details` is included outside production so local debugging still works.
+ */
+export function apiError(error: unknown, publicMessage: string) {
+  console.error(`${publicMessage}:`, error)
+
+  return NextResponse.json(
+    {
+      error: publicMessage,
+      timestamp: new Date().toISOString(),
+      ...(process.env.NODE_ENV !== 'production' && {
+        details: error instanceof Error ? error.stack : String(error),
+      }),
+    },
+    { status: 500 },
+  )
+}


### PR DESCRIPTION
Every API route's catch block put `error.stack` into `details` and `error.message` into `message` in its 500 body — and since everything runs through the service-role Supabase client, those were raw Postgres/PostgREST errors carrying table, column and constraint names plus absolute server file paths. All 500s now go through a single `apiError(error, publicMessage)` helper (`lib/apiError.ts`) that logs the real error server-side, returns `{ error: publicMessage, timestamp }` only, and includes `details` when `NODE_ENV !== 'production'` so local debugging is unaffected.

## Converted call sites

**18 copies of the duplicated block across 16 files** (the issue estimated ~10):

- `app/api/queries/locations/route.ts`
- `app/api/queries/megagame_locations/route.ts`
- `app/api/queries/profiles/route.ts` (GET + POST)
- `app/api/queries/profiles/[userId]/route.ts`
- `app/api/queries/profiles/current/route.ts`
- `app/api/queries/profiles/public/route.ts` (GET + POST)
- `app/api/queries/profiles/public/[userId]/route.ts`
- `app/api/queries/rsvps/route.ts`
- `app/api/queries/rsvps/[userId]/route.ts`
- `app/api/queries/rsvps/current/route.ts`
- `app/api/queries/session-bookmarks/route.ts`
- `app/api/queries/session-bookmarks/[userId]/route.ts`
- `app/api/queries/session-bookmarks/current/route.ts`
- `app/api/queries/sessions/route.ts`
- `app/api/queries/sessions/[id]/route.ts`
- `app/api/queries/sessions/[id]/ics/route.ts`

Plus 4 near-identical leaks the issue didn't list, found by sweeping all of `app/api/**`:

- `app/api/create-payment-intent/route.ts` — inner catch returned `` `Failed to create payment intent: ${error}` ``; outer catch returned `details: error.message`
- `app/api/confirm-payment/route.ts` — returned `error: error.message` directly as the user-visible message
- `app/api/cron/repair-waitlists/route.ts` — returned `message: error.message`

`get-coupon-display`, `validate-coupon` and the OpenNode webhook already returned generic messages; the 400/Zod paths in the payment routes are untouched, since those messages are deliberately user-facing.

Caller side: `handleApiError` in `hooks/schedule/queries.ts` preferred `errorData.message` over `errorData.error`; it now reads `errorData.error` (the generic message) so schedule toasts still say something useful instead of going blank. It still logs `errorData.details` when present, which is now dev-only. No other client reads `message`/`details` — everything else reads `.error`, whose value is unchanged.

Two deliberate behavior changes worth a look:
- Checkout failures now surface "Payment confirmation failed" / "Failed to create payment intent" instead of the raw Stripe/Airtable/Postgres message. Safer, but less self-diagnosing for the buyer.
- The confirm-payment 500 body no longer carries `success: false`. `TicketPurchaseForm` checks `!response.ok` before it checks `success`, so the flow is unaffected.

Edits are confined to the bottom of each handler (catch blocks) to stay merge-clean with META-397's auth checks at the top of the same `app/api/queries/**` files.

## Testing required

Everything below is on the preview deploy.

**500s must not leak internals.** Hit a route with a parameter that blows up in Postgres — a non-UUID where a UUID is expected:

```
curl -s https://<preview>/api/queries/sessions/not-a-uuid | jq
curl -s https://<preview>/api/queries/profiles/public/not-a-uuid | jq
curl -s https://<preview>/api/queries/rsvps/not-a-uuid | jq
curl -s https://<preview>/api/queries/session-bookmarks/not-a-uuid | jq
```

Each should be a 500 whose body is exactly `{"error": "...", "timestamp": "..."}` — no `stack`, no `details`, no `message`, no table/column/constraint names (`sessions`, `session_rsvps`, `profiles_pkey`, `invalid input syntax for type uuid`), and no `/var/task/...` paths. If any of these returns 200 instead, force an error a different way (e.g. a malformed POST body to `/api/queries/profiles/public`).

**Happy paths still work.** Load `/schedule` (sessions, locations, RSVPs, bookmarks all fetch), open a session modal, download an `.ics` from a session card, load `/profile`, and check `curl -s https://<preview>/api/queries/sessions | jq 'length'` returns the expected count.

**UI still shows something useful on failure.** With the network tab open, block or fail `/api/queries/sessions` (DevTools request blocking) and confirm the schedule surfaces a real message rather than an empty toast — it should now read "Failed to fetch sessions".

**Checkout.** Walk a test purchase through `/tickets` to confirm the success path is untouched, and eyeball that a forced failure shows the new generic copy rather than a blank message.

### Can't be verified on the preview

`details` is gated on `NODE_ENV !== 'production'`, and Vercel previews build with `NODE_ENV=production`. So the dev-only branch of `apiError` never fires there — the preview can only confirm the production behavior (no `details`). Verifying that `details` still appears locally requires `pnpm dev`, which I did not run.