### PR TITLE
Harden ticket and payment integrity paths [META-401]

### DIFF
--- a/app/actions/db/tickets.ts
+++ b/app/actions/db/tickets.ts
@@ -38,6 +38,12 @@ export const signupByTicketCode = async ({
   const supabase = createServiceClient()
   const existingUser = await usersService.getUserFullProfileByEmail({ email })
   if (existingUser) {
+    // Anyone can type in someone else's address, so attaching a ticket to an
+    // account that already exists requires proof the caller controls it.
+    const currentUser = await usersService.getCurrentUser()
+    if (!currentUser || currentUser.id !== existingUser.id) {
+      return { success: false, error: 'sign_in_required', ticket: null }
+    }
     userId = existingUser.id
     const userHasTicket = await ticketsService.getTicketsByOwnerId({
       ownerId: userId,
@@ -68,14 +74,20 @@ export const signupByTicketCode = async ({
     userId = user.id
   }
   await ticketsService.updateTicketOwner({ ticketCode, ownerId: userId })
-  await usersService.updateUserProfile({
-    userId,
-    data: {
-      team: [TEAM_COLORS.ORANGE, TEAM_COLORS.PURPLE][
-        Math.floor(Math.random() * 2)
-      ],
-    },
-  })
+  // Teams are assigned once. Claiming another ticket must not reroll the team of
+  // someone who already has one.
+  const profile =
+    existingUser ?? (await usersService.getUserFullProfile({ userId }))
+  if (!profile?.team || profile.team === TEAM_COLORS.UNASSIGNED) {
+    await usersService.updateUserProfile({
+      userId,
+      data: {
+        team: [TEAM_COLORS.ORANGE, TEAM_COLORS.PURPLE][
+          Math.floor(Math.random() * 2)
+        ],
+      },
+    })
+  }
   return { success: true, error: null, ticket: ticket }
 }
 export const volunteerGetAllFullTickets = async () => {

--- a/app/api/checkout/opennode/route.ts
+++ b/app/api/checkout/opennode/route.ts
@@ -12,7 +12,7 @@ import {
 } from '@/lib/schemas/opennode'
 
 import { getHostedCheckoutUrl } from '@/utils/opennode'
-import { currentUserHasAuthLevel } from '@/utils/security'
+import { authLevelsToRanks, getCurrentUserAuthRank } from '@/utils/security'
 
 import { btcSlidingScaleMinimum, ticketTypeDetails } from '@/config/tickets'
 import { DbTicketType } from '@/types/database/dbTypeAliases'
@@ -42,7 +42,8 @@ export async function POST(req: NextRequest) {
   const ticketTitle = ticketType?.title || 'Unknown'
   const ticketPriceBtc = ticketType?.priceBTC
 
-  const userIsAdmin = await currentUserHasAuthLevel({ authLevel: 'ADMIN' })
+  const userIsAdmin =
+    (await getCurrentUserAuthRank()) >= authLevelsToRanks.ADMIN
 
   // The charge amount is what the buyer actually has to pay for a real ticket, so
   // it comes from config, not from the request. The only exception is the sliding

--- a/app/api/checkout/opennode/route.ts
+++ b/app/api/checkout/opennode/route.ts
@@ -12,37 +12,73 @@ import {
 } from '@/lib/schemas/opennode'
 
 import { getHostedCheckoutUrl } from '@/utils/opennode'
-
-import { getCurrentUserAdminStatus } from '@/app/actions/db/users'
+import { currentUserHasAuthLevel } from '@/utils/security'
 
 import { btcSlidingScaleMinimum, ticketTypeDetails } from '@/config/tickets'
+import { DbTicketType } from '@/types/database/dbTypeAliases'
 
 const resend = new Resend(process.env.RESEND_API_KEY)
 
+const SATOSHIS_PER_BTC = 100_000_000
+/** The one ticket type whose price the buyer picks. */
+const BTC_SLIDING_SCALE_TICKET_TYPE: DbTicketType = 'player'
+
+const btcToSatoshis = (btc: number) => Math.round(btc * SATOSHIS_PER_BTC)
+
 export async function POST(req: NextRequest) {
-  const { amountBtc, ticketDetails } = opennodeChargeSchema.parse(
-    await req.json(),
-  )
+  const parsed = opennodeChargeSchema.safeParse(await req.json())
+  if (!parsed.success) {
+    return NextResponse.json(
+      { error: 'Invalid charge request' },
+      { status: 400 },
+    )
+  }
+  const { amountBtc, ticketDetails } = parsed.data
   const metagameOrderId = uuidv4()
   const callback = `${getSiteUrl()}/api/checkout/opennode/webhook`
   const successUrl = `${getSiteUrl()}/checkout/status/${metagameOrderId}`
-
-  const amountSatoshis = Math.round(amountBtc * 100000000)
 
   const ticketType = ticketTypeDetails[ticketDetails.ticketType]
   const ticketTitle = ticketType?.title || 'Unknown'
   const ticketPriceBtc = ticketType?.priceBTC
 
-  // If the provided bitcoin price doesn't match the ticket price, only admins can proceed otherwise throw error
-  if (!ticketPriceBtc || ticketPriceBtc < btcSlidingScaleMinimum) {
-    const userIsAdmin = await getCurrentUserAdminStatus()
-    if (!userIsAdmin) {
+  const userIsAdmin = await currentUserHasAuthLevel({ authLevel: 'ADMIN' })
+
+  // The charge amount is what the buyer actually has to pay for a real ticket, so
+  // it comes from config, not from the request. The only exception is the sliding
+  // scale type, where the buyer chooses — floored at the minimum.
+  let amountSatoshis: number
+  if (userIsAdmin) {
+    const adminAmountBtc = amountBtc ?? ticketPriceBtc
+    if (!adminAmountBtc) {
       return NextResponse.json(
-        { error: 'Invalid ticket price' },
+        { error: 'No amount provided for this ticket type' },
         { status: 400 },
       )
     }
+    amountSatoshis = btcToSatoshis(adminAmountBtc)
+  } else if (!ticketPriceBtc) {
+    return NextResponse.json(
+      { error: 'Bitcoin payment is not available for this ticket type' },
+      { status: 400 },
+    )
+  } else if (ticketDetails.ticketType === BTC_SLIDING_SCALE_TICKET_TYPE) {
+    const requestedBtc = amountBtc ?? ticketPriceBtc
+    if (requestedBtc < btcSlidingScaleMinimum) {
+      return NextResponse.json(
+        { error: 'Amount is below the sliding scale minimum' },
+        { status: 400 },
+      )
+    }
+    amountSatoshis = btcToSatoshis(requestedBtc)
+  } else {
+    amountSatoshis = btcToSatoshis(ticketPriceBtc)
   }
+
+  // Only admins get to label an order as test data.
+  const isTest = userIsAdmin
+    ? (ticketDetails.isTest ?? false)
+    : process.env.OPENNODE_ENV === 'dev'
 
   const charge = await createChargeRaw({
     amount: amountSatoshis,
@@ -54,7 +90,7 @@ export async function POST(req: NextRequest) {
     success_url: successUrl,
   })
 
-  await opennodeDbService.createCharge({ charge, ticketDetails })
+  await opennodeDbService.createCharge({ charge, ticketDetails, isTest })
 
   // Send email to purchaser with payment link
   try {

--- a/app/api/checkout/opennode/webhook/route.ts
+++ b/app/api/checkout/opennode/webhook/route.ts
@@ -76,13 +76,37 @@ export async function POST(req: NextRequest) {
   })
 
   if (body.status === 'paid') {
+    // OpenNode retries callbacks, so a ticket must only be minted once per order.
+    const existingTicket = await ticketsService.getTicketByOpennodeOrder({
+      orderId: dbCharge.id,
+    })
+    if (existingTicket) {
+      console.log('opennode order already has a ticket', dbCharge.id)
+      return NextResponse.json({ received: true })
+    }
+
+    // Never issue a ticket for less than the charge was created for.
+    const satoshisPaid = body.amount - (body.missing_amt ?? 0)
+    if (satoshisPaid < dbCharge.satoshis) {
+      console.error(
+        'opennode charge marked paid for less than the charge amount',
+        dbCharge.id,
+        satoshisPaid,
+        dbCharge.satoshis,
+      )
+      await sendAdminErrorEmail(
+        `Underpaid opennode charge marked paid; no ticket issued: ${JSON.stringify(dbCharge)}`,
+      )
+      return NextResponse.json({ received: true })
+    }
+
     const newTicket = {
       opennode_order: dbCharge.id,
       ticket_type: dbCharge.ticket_type!,
       purchaser_email: dbCharge.purchaser_email,
       purchaser_name: dbCharge.purchaser_name || '',
       is_test: dbCharge.is_test,
-      satoshis_paid: body.amount,
+      satoshis_paid: satoshisPaid,
     }
     await ticketsService.createTicket({ ticket: newTicket })
 

--- a/app/api/confirm-payment/route.ts
+++ b/app/api/confirm-payment/route.ts
@@ -5,8 +5,19 @@ import { NextRequest, NextResponse } from 'next/server'
 import { ZodError } from 'zod'
 
 import { apiError } from '@/lib/apiError'
+import { couponsService } from '@/lib/db/coupons'
 import { ticketsService } from '@/lib/db/tickets'
 import { sendTicketConfirmationEmail } from '@/lib/email'
+
+import { TICKET_TYPES_ENUM } from '@/utils/dbUtils'
+
+import { DbTicketType } from '@/types/database/dbTypeAliases'
+
+const asTicketType = (value: string | undefined): DbTicketType | null =>
+  TICKET_TYPES_ENUM.find((type) => type === value) ?? null
+
+const emailsMatch = (a: string, b: string) =>
+  a.trim().toLowerCase() === b.trim().toLowerCase()
 
 export async function POST(request: NextRequest) {
   try {
@@ -14,8 +25,7 @@ export async function POST(request: NextRequest) {
 
     // Validate input using Zod schema
     const validatedData = paymentConfirmationSchema.parse(body)
-    console.log('VALIDATEDDATA', validatedData)
-    const { paymentIntentId, name, email, ticketType } = validatedData
+    const { paymentIntentId } = validatedData
 
     // Retrieve payment intent from Stripe to check its status
     const paymentIntent = await stripe.paymentIntents.retrieve(
@@ -32,6 +42,74 @@ export async function POST(request: NextRequest) {
         success: false,
         error: `Payment not succeeded. Status: ${paymentIntent.status}`,
         paymentIntentId,
+      })
+    }
+
+    // The intent's metadata was written server-side at intent creation, so it —
+    // not the request body — decides what ticket is minted and who gets it. The
+    // body is only allowed to agree.
+    const ticketType = asTicketType(paymentIntent.metadata.ticketTypeId)
+    const email = paymentIntent.metadata.customerEmail
+    const name = paymentIntent.metadata.customerName
+    const expectedAmount = Number(paymentIntent.metadata.finalPrice)
+
+    if (!ticketType || !email || !name || !Number.isFinite(expectedAmount)) {
+      console.error(
+        'Payment intent is missing purchase metadata',
+        paymentIntentId,
+        paymentIntent.metadata,
+      )
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Payment intent is missing purchase details',
+        },
+        { status: 400 },
+      )
+    }
+
+    if (
+      ticketType !== validatedData.ticketType ||
+      !emailsMatch(email, validatedData.email)
+    ) {
+      console.error(
+        'Confirmation request does not match payment intent metadata',
+        paymentIntentId,
+      )
+      return NextResponse.json(
+        {
+          success: false,
+          error: 'Purchase details do not match the payment',
+        },
+        { status: 400 },
+      )
+    }
+
+    if (paymentIntent.amount !== expectedAmount) {
+      console.error(
+        'Payment intent amount does not match the quoted price',
+        paymentIntentId,
+        paymentIntent.amount,
+        expectedAmount,
+      )
+      return NextResponse.json(
+        { success: false, error: 'Payment amount mismatch' },
+        { status: 400 },
+      )
+    }
+
+    // Confirmation is replayable (retries, double submits, a hostile caller), so
+    // one payment intent must only ever produce one ticket.
+    const existingTicket = await ticketsService.getTicketByStripePaymentId({
+      stripePaymentId: paymentIntentId,
+    })
+    if (existingTicket) {
+      return NextResponse.json({
+        success: true,
+        paymentIntentId,
+        alreadyProcessed: true,
+        message:
+          'This payment has already been confirmed. Check your email for your ticket.',
       })
     }
 
@@ -100,19 +178,57 @@ export async function POST(request: NextRequest) {
 
     const airtableResult = await createTicketRecord(airtableRecord)
 
+    const couponCode = paymentIntent.metadata.couponCode
     const supabaseTicketRecord = {
       stripe_payment_id: paymentIntentId,
       purchaser_email: email,
       purchaser_name: name,
       ticket_type: ticketType,
       price_paid: price,
-      coupons_used: [paymentIntent.metadata.couponCode],
+      coupons_used: couponCode ? [couponCode] : [],
       is_test: process.env.STRIPE_SECRET_KEY?.startsWith('sk_test') ?? false,
     }
 
-    const createdTicket = await ticketsService.createTicket({
-      ticket: supabaseTicketRecord,
-    })
+    let createdTicket: Awaited<ReturnType<typeof ticketsService.createTicket>>
+    try {
+      createdTicket = await ticketsService.createTicket({
+        ticket: supabaseTicketRecord,
+      })
+    } catch (createError) {
+      // A concurrent confirmation may have won the race against the unique index
+      // on stripe_payment_id; that's the idempotent case, not a failure.
+      const raced = await ticketsService.getTicketByStripePaymentId({
+        stripePaymentId: paymentIntentId,
+      })
+      if (!raced) throw createError
+      return NextResponse.json({
+        success: true,
+        paymentIntentId,
+        alreadyProcessed: true,
+        message:
+          'This payment has already been confirmed. Check your email for your ticket.',
+      })
+    }
+
+    // Redeem the coupon only now that the payment succeeded and the ticket exists —
+    // an abandoned checkout must not burn a use.
+    const couponId = paymentIntent.metadata.couponId
+    if (couponId) {
+      try {
+        const redeemed = await couponsService.redeem({ id: couponId })
+        if (!redeemed) {
+          console.error(
+            'Coupon could not be redeemed after successful payment',
+            couponId,
+            paymentIntentId,
+          )
+        }
+      } catch (couponError) {
+        // The customer has already paid and holds a ticket; a bookkeeping failure
+        // must not fail the purchase.
+        console.error('Failed to redeem coupon:', couponError)
+      }
+    }
 
     // Send confirmation email
     try {

--- a/app/api/create-payment-intent/route.ts
+++ b/app/api/create-payment-intent/route.ts
@@ -5,7 +5,6 @@ import { NextRequest, NextResponse } from 'next/server'
 import { ZodError } from 'zod'
 
 import { apiError } from '@/lib/apiError'
-import { couponsService } from '@/lib/db/coupons'
 
 import { ticketTypeDetails, usdSlidingScaleMinimum } from '@/config/tickets'
 
@@ -72,13 +71,18 @@ export async function POST(request: NextRequest) {
         { status: 400 },
       )
     }
-    // Create payment intent
+    // Create payment intent. This metadata is what confirm-payment trusts when it
+    // mints the ticket, so everything that decides *what* the customer receives
+    // has to be recorded here, server-side.
     const metadata = {
       ticketType: ticketType.title,
+      ticketTypeId,
       customerName: name,
       customerEmail: email,
       originalPrice: originalPriceInCents.toString(),
+      finalPrice: finalPriceInCents.toString(),
       couponCode: coupon?.code || '',
+      couponId: coupon?.id || '',
       discountAmount: coupon ? coupon.discountAmountCents.toString() : '0',
     }
     let clientSecret: string
@@ -91,14 +95,9 @@ export async function POST(request: NextRequest) {
     } catch (error) {
       return apiError(error, 'Failed to create payment intent')
     }
-    if (coupon) {
-      couponsService.update({
-        id: coupon.id,
-        data: {
-          used_count: coupon.usedCount + 1,
-        },
-      })
-    }
+    // The coupon is deliberately *not* consumed here — an intent is only a quote,
+    // and abandoning checkout shouldn't burn a use. confirm-payment redeems it
+    // atomically once the payment has succeeded.
     return NextResponse.json({
       clientSecret,
       paymentIntentId,

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -97,6 +97,18 @@ function SignupForm() {
         })
         return
       }
+      if (res.error === 'sign_in_required') {
+        setErrors({
+          submit:
+            'An account already exists for this email. Please log in first, then claim your ticket.',
+        })
+        setShowResetPasswordLink(true)
+        return
+      }
+      if (!res.success) {
+        setErrors({ submit: res.error ?? 'Signup failed' })
+        return
+      }
 
       router.push(`/signup/success?email=${validatedData.email}`)
     } catch (error) {

--- a/lib/db/coupons.ts
+++ b/lib/db/coupons.ts
@@ -72,6 +72,20 @@ export const couponsService = {
     }
     return updated
   },
+  /** Atomically consume one use of a coupon. Returns the updated coupon, or null
+   * if the coupon is disabled or already at its max uses — the check and the
+   * increment happen in one statement so concurrent redemptions can't overrun it.
+   * Requires the `redeem_coupon` function (see supabase/migrations). */
+  redeem: async ({ id }: { id: string }) => {
+    const supabase = createServiceClient()
+    const { data, error } = await supabase.rpc('redeem_coupon', {
+      coupon_id: id,
+    })
+    if (error) {
+      throw new Error(error.message)
+    }
+    return data?.[0] ?? null
+  },
   upsertByCode: async ({ coupon }: { coupon: DbCouponInsert }) => {
     const existing = await couponsService.getByCode({
       couponCode: coupon.coupon_code,

--- a/lib/db/opennode.ts
+++ b/lib/db/opennode.ts
@@ -10,9 +10,12 @@ export const opennodeDbService = {
   createCharge: async ({
     charge,
     ticketDetails,
+    isTest,
   }: {
     charge: OpenNodeCharge
     ticketDetails: OpennodeChargeInput['ticketDetails']
+    /** Resolved by the route, not taken from ticketDetails — see the schema. */
+    isTest: boolean
   }) => {
     const supabase = createServiceClient()
     const { data, error } = await supabase.from('opennode_orders').insert({
@@ -23,7 +26,7 @@ export const opennodeDbService = {
       purchaser_email: ticketDetails.purchaserEmail,
       purchaser_name: ticketDetails.purchaserName,
       ticket_type: ticketDetails.ticketType,
-      is_test: ticketDetails.isTest,
+      is_test: isTest,
     })
     if (error) {
       throw new Error(

--- a/lib/db/tickets.ts
+++ b/lib/db/tickets.ts
@@ -1,3 +1,5 @@
+import { randomInt } from 'crypto'
+
 import { createServiceClient } from '@/utils/supabase/service'
 
 import { DbFullTicket, DbTicketInsert } from '@/types/database/dbTypeAliases'
@@ -6,6 +8,16 @@ const ticketsSelectIncludes = `
   *,
   owner:profiles!tickets_owner_id_fkey(*, celestial_card:celestial_cards!profiles_celestial_card_id_fkey(*))
 `
+
+const TICKET_CODE_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'
+const TICKET_CODE_LENGTH = 8
+
+/** Ticket codes are bearer credentials for claiming a ticket, so they must not
+ * be guessable from other codes — Math.random() is not a CSPRNG. */
+const generateTicketCode = () =>
+  Array.from({ length: TICKET_CODE_LENGTH }, () =>
+    TICKET_CODE_ALPHABET.charAt(randomInt(TICKET_CODE_ALPHABET.length)),
+  ).join('')
 export const ticketsService = {
   getAllTickets: async () => {
     const supabase = createServiceClient()
@@ -35,18 +47,12 @@ export const ticketsService = {
     ticket: Omit<DbTicketInsert, 'ticket_code'>
   }) => {
     const supabase = createServiceClient()
-    const generatedTicketCode = Array.from({ length: 8 }, () =>
-      'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789'.charAt(
-        Math.floor(Math.random() * 36),
-      ),
-    ).join('')
-    console.log(ticket)
     const { data, error } = await supabase
       .from('tickets')
       .insert({
         ...ticket,
         owner_id: ticket.owner_id || null,
-        ticket_code: generatedTicketCode,
+        ticket_code: generateTicketCode(),
       })
       .select()
       .single()
@@ -61,7 +67,35 @@ export const ticketsService = {
       .from('tickets')
       .select('*')
       .eq('ticket_code', code)
-      .single()
+      .maybeSingle()
+    if (error) {
+      throw new Error(error.message)
+    }
+    return data
+  },
+  getTicketByStripePaymentId: async ({
+    stripePaymentId,
+  }: {
+    stripePaymentId: string
+  }) => {
+    const supabase = createServiceClient()
+    const { data, error } = await supabase
+      .from('tickets')
+      .select('*')
+      .eq('stripe_payment_id', stripePaymentId)
+      .maybeSingle()
+    if (error) {
+      throw new Error(error.message)
+    }
+    return data
+  },
+  getTicketByOpennodeOrder: async ({ orderId }: { orderId: string }) => {
+    const supabase = createServiceClient()
+    const { data, error } = await supabase
+      .from('tickets')
+      .select('*')
+      .eq('opennode_order', orderId)
+      .maybeSingle()
     if (error) {
       throw new Error(error.message)
     }

--- a/lib/schemas/opennode.ts
+++ b/lib/schemas/opennode.ts
@@ -4,7 +4,9 @@ import { TICKET_TYPES_ENUM } from '@/utils/dbUtils'
 
 export const ticketPurchaseDetailsSchema = z.object({
   ticketType: z.enum(TICKET_TYPES_ENUM),
-  isTest: z.boolean(),
+  /** Only honored for admins (the admin charge tool). For everyone else the
+   * server decides, so a real order can't disguise itself as test data. */
+  isTest: z.boolean().optional(),
   purchaserEmail: z.email(),
   purchaserName: z.string().optional(),
 })
@@ -12,7 +14,9 @@ export const ticketPurchaseDetailsSchema = z.object({
 export type TicketPurchaseDetails = z.infer<typeof ticketPurchaseDetailsSchema>
 
 export const opennodeChargeSchema = z.object({
-  amountBtc: z.number().positive(),
+  /** Only honored for the sliding-scale ticket type (or admins). Every other
+   * ticket type is charged its configured price, derived server-side. */
+  amountBtc: z.number().positive().optional(),
   ticketDetails: ticketPurchaseDetailsSchema,
 })
 

--- a/supabase/migrations/20260721170000_ticket_payment_uniqueness.sql
+++ b/supabase/migrations/20260721170000_ticket_payment_uniqueness.sql
@@ -1,0 +1,11 @@
+-- One ticket per payment. The confirm-payment route and the OpenNode webhook can
+-- both be replayed (by a caller or by OpenNode's retries), so the database is the
+-- last line of defense against minting duplicate tickets for one payment.
+-- Partial indexes: admin-issued tickets have neither id set.
+create unique index if not exists tickets_stripe_payment_id_key
+  on public.tickets (stripe_payment_id)
+  where stripe_payment_id is not null;
+
+create unique index if not exists tickets_opennode_order_key
+  on public.tickets (opennode_order)
+  where opennode_order is not null;

--- a/supabase/migrations/20260721170100_redeem_coupon.sql
+++ b/supabase/migrations/20260721170100_redeem_coupon.sql
@@ -1,0 +1,18 @@
+-- Atomically consume one use of a coupon.
+-- Checking used_count in application code and writing back count + 1 lets
+-- concurrent redemptions overwrite each other; doing the check and the increment
+-- in one statement can't. Returns no rows when the coupon is disabled or spent,
+-- which the caller treats as "not redeemable".
+create or replace function public.redeem_coupon(coupon_id uuid)
+returns setof public.coupons
+language sql
+security definer
+set search_path = public, pg_temp
+as $$
+  update public.coupons
+  set used_count = used_count + 1
+  where id = coupon_id
+    and enabled
+    and (max_uses is null or used_count < max_uses)
+  returning *;
+$$;

--- a/types/database/supabase.types.ts
+++ b/types/database/supabase.types.ts
@@ -832,6 +832,20 @@ export type Database = {
         Args: Record<PropertyKey, never>
         Returns: number
       }
+      redeem_coupon: {
+        Args: { coupon_id: string }
+        Returns: {
+          coupon_code: string
+          created_at: string
+          description: string | null
+          discount_amount_cents: number
+          email_for: boolean
+          enabled: boolean
+          id: string
+          max_uses: number | null
+          used_count: number
+        }[]
+      }
     }
     Enums: {
       AGES: "ADULTS" | "KIDS" | "ALL"


### PR DESCRIPTION
Ticket sales are retired on the 2025 site, so none of these holes were live or exploitable — this is hardening so the patterns don't get copied into a future year's checkout. Every fix is the same shape: stop trusting a client-supplied value that decides what the customer receives.

- **confirm-payment mints only what was paid for.** Ticket type, purchaser name/email and amount now come from the Stripe intent's metadata (written server-side at intent creation); the request body is only allowed to *agree* with it, and a mismatch is a 400. Previously the body's `ticketType`/`email` went straight into the ticket.
- **confirm-payment is idempotent.** It returns the already-processed response if a ticket exists for that `stripe_payment_id`, and treats a losing insert race the same way. Backed by a unique index (migration below).
- **create-payment-intent** now records `ticketTypeId`, `finalPrice` and `couponId` in intent metadata (it only recorded the human-readable title before, which confirm-payment couldn't check against).
- **Coupon redemption** moved out of intent creation (a quote) into confirm-payment after `succeeded`, is awaited, and goes through a new atomic `redeem_coupon()` that checks `max_uses` and increments in one statement. Abandoning checkout no longer burns a use; concurrent redemptions can't overrun the cap. A redemption failure logs but doesn't fail a purchase the customer already paid for.
- **OpenNode charge amount is derived server-side** from `ticketTypeDetails[...].priceBTC`. The client-supplied `amountBtc` is honored only for the sliding-scale (`player`) type, floored at `btcSlidingScaleMinimum`, and for admins (the admin charge tool still needs arbitrary amounts).
- **Day-pass BTC purchases work again.** The old guard compared the *config* price against `btcSlidingScaleMinimum`, so friday/saturday/sunday (0.0011–0.0018) were rejected for every non-admin. The minimum now only applies to the sliding-scale type.
- **`isTest` is no longer client-supplied** — it's `OPENNODE_ENV === 'dev'` server-side, and only admins may set it explicitly, so a fraudulent order can't self-label to hide in test data. `opennodeDbService.createCharge` takes the resolved value as its own argument.
- **OpenNode webhook** is idempotent per order (OpenNode retries callbacks) and refuses to issue a ticket when the paid amount is below the charge amount, emailing admins instead. `satoshis_paid` records what was actually paid.
- **`signupByTicketCode`**: binding a ticket to an *existing* account now requires being signed in as that account (`sign_in_required`), instead of trusting an unverified email; `team` is only assigned when the profile has none, so a returning player's team is no longer rerolled; unknown ticket codes now actually hit the not-found branch (`getTicketByCode` uses `maybeSingle()`, so the dead `if (!ticket)` after `.single()` is live).
- **Ticket codes** use `crypto.randomInt` instead of `Math.random()` — they're bearer credentials for claiming a ticket.
- Drive-bys: the signup page now surfaces `success: false` results instead of redirecting to the success page anyway; dropped a `console.log` of the full ticket payload.

### Deviations from the issue

- **No rate limiting** on `signupByTicketCode`. There's no rate-limit primitive in this repo and an in-memory one is worthless on serverless; requiring auth for the existing-account branch plus CSPRNG codes removes the enumeration payoff. A future checkout should put a real limiter (Upstash/Supabase) in front of it.
- Requiring sign-in for the existing-account branch means a returning buyer currently has no in-app path to claim a ticket (there is no signed-in "claim" flow). Correct security posture, but a future year needs that flow built — flagged rather than papered over.
- `redeem_coupon()` doesn't touch `coupon_emails.uses`. Per-email use limits are *validated* but never incremented anywhere in the codebase today; fixing that is a separate change.

## Testing required

This code path is **dormant** — the ticket UI is removed from the 2025 site, so almost none of this can be exercised in the preview deploy. Please don't read a green preview as verification.

**Checkable in-browser (preview):** effectively nothing beyond "the site still builds and unrelated pages render". The `/signup` ticket-code page is the only reachable surface, and exercising it needs a real unclaimed ticket code.

**Cannot be verified without live Stripe/OpenNode.** Whoever revives checkout must test:
1. Create a test-mode intent for a day pass, then POST `/api/confirm-payment` with `ticketType: 'supporter'` → rejected with "Purchase details do not match the payment" and no ticket created. Same with a swapped `email`.
2. Replay a successful confirm twice → second call returns `alreadyProcessed: true`, exactly one ticket row, one confirmation email.
3. Tamper with the intent amount (or hand-craft metadata) so `paymentIntent.amount !== metadata.finalPrice` → rejected.
4. BTC: request a `friday` charge with `amountBtc: 0.00000001` as an anonymous user → charge is created for the configured 0.0011 BTC, not the requested amount. And a legitimate friday/saturday/sunday BTC purchase now succeeds for non-admins (it used to 400).
5. BTC sliding scale (`player`): below `btcSlidingScaleMinimum` → 400; at or above → honored.
6. Underpaid/replayed OpenNode webhook: a `paid` callback with `missing_amt > 0` → no ticket, admin error email; a duplicate `paid` callback → no second ticket.
7. Coupon: abandon checkout after creating an intent → `used_count` unchanged; complete the purchase → `used_count` +1 exactly once, and a coupon at `max_uses` can't be redeemed.
8. Ticket-code signup with an email that already has a profile, while logged out → `sign_in_required`, ticket not bound, existing user's `team` unchanged.
9. Admin OpenNode charge tool still creates arbitrary-amount charges and can mark them as test.

**Manual steps (nobody runs these automatically):**
- Apply `supabase/migrations/20260721170000_ticket_payment_uniqueness.sql` — unique indexes on `tickets.stripe_payment_id` and `tickets.opennode_order` (partial, `where … is not null`). **This will fail if prod already contains duplicate rows for either column** — check and dedupe first.
- Apply `supabase/migrations/20260721170100_redeem_coupon.sql` — `redeem_coupon(uuid)`. **Coupon redemption throws until this exists**, so confirm-payment logs a redemption failure (the purchase still completes).
- `types/database/supabase.types.ts` was hand-edited to add the `redeem_coupon` signature since the types can't be regenerated here; re-run `pnpm types:supabase:prod` after applying the migrations to confirm it matches.
