### PR TITLE
Require a session for the attendee-data API routes [META-397]

### DIFF
--- a/app/api/apiAuth.ts
+++ b/app/api/apiAuth.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+
+import { createClient } from '@/utils/supabase/server'
+
+/** The signed-in user for an API request, or null when the caller is anonymous. */
+export const getApiUser = async () => {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  return user
+}
+
+export const unauthorizedResponse = () =>
+  NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/app/api/queries/profiles/public/[userId]/route.ts
+++ b/app/api/queries/profiles/public/[userId]/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server'
 
 import { apiError } from '@/lib/apiError'
+import { stripPrivateProfileFields } from '@/lib/profiles'
 
 import { getUserPublicProfileById } from '@/app/actions/db/users'
+import { getApiUser } from '@/app/api/apiAuth'
 
 import { DbPublicProfile } from '@/types/database/dbTypeAliases'
 
@@ -12,19 +14,22 @@ export async function GET(
   { params }: { params: Promise<{ userId: string }> },
 ) {
   try {
+    // Anonymous callers get the card-facing profile, minus the fields only
+    // attendees may see
+    const user = await getApiUser()
+
     const { userId } = await params
 
     const profile = await getUserPublicProfileById({ userId })
+    const visibleProfile =
+      profile && !user ? stripPrivateProfileFields(profile) : profile
 
     const response = NextResponse.json(
-      profile satisfies ApiUserPublicProfileResponse,
+      visibleProfile satisfies ApiUserPublicProfileResponse,
     )
 
-    // Add cache headers - profiles don't change often
-    response.headers.set(
-      'Cache-Control',
-      'public, s-maxage=300, stale-while-revalidate=86400',
-    )
+    // Varies by session, so it can't sit in a shared cache
+    response.headers.set('Cache-Control', 'private, no-store')
 
     return response
   } catch (error) {

--- a/app/api/queries/profiles/public/route.ts
+++ b/app/api/queries/profiles/public/route.ts
@@ -1,28 +1,30 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { apiError } from '@/lib/apiError'
+import { stripPrivateProfileFields } from '@/lib/profiles'
 
 import {
   getAllUserPublicProfiles,
   getUsersPublicProfiles,
 } from '@/app/actions/db/users'
+import { getApiUser, unauthorizedResponse } from '@/app/api/apiAuth'
 
 import { DbPublicProfile } from '@/types/database/dbTypeAliases'
 
 export type ApiAllPublicProfilesResponse = DbPublicProfile[]
 export async function GET() {
   try {
+    // The whole attendee roster is attendees-only
+    const user = await getApiUser()
+    if (!user) return unauthorizedResponse()
+
     const profiles = await getAllUserPublicProfiles()
 
     const response = NextResponse.json(
       profiles satisfies ApiAllPublicProfilesResponse,
     )
 
-    // Add cache headers - profiles don't change often
-    response.headers.set(
-      'Cache-Control',
-      'public, s-maxage=300, stale-while-revalidate=86400',
-    )
+    response.headers.set('Cache-Control', 'private, no-store')
 
     return response
   } catch (error) {
@@ -33,18 +35,22 @@ export async function GET() {
 export type ApiUsersPublicProfilesResponse = DbPublicProfile[]
 export async function POST(request: NextRequest) {
   try {
+    // Anonymous callers get these (speaker and team card grids), minus the
+    // fields only attendees may see
+    const user = await getApiUser()
+
     const { userIds } = (await request.json()) as { userIds: string[] }
     const profiles = await getUsersPublicProfiles({ userIds })
+    const visibleProfiles = user
+      ? profiles
+      : profiles.map(stripPrivateProfileFields)
 
     const response = NextResponse.json(
-      profiles satisfies ApiUsersPublicProfilesResponse,
+      visibleProfiles satisfies ApiUsersPublicProfilesResponse,
     )
 
-    // Add cache headers - profiles don't change often
-    response.headers.set(
-      'Cache-Control',
-      'public, s-maxage=300, stale-while-revalidate=86400',
-    )
+    // Varies by session, so it can't sit in a shared cache
+    response.headers.set('Cache-Control', 'private, no-store')
 
     return response
   } catch (error) {

--- a/app/api/queries/rsvps/[userId]/route.ts
+++ b/app/api/queries/rsvps/[userId]/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { apiError } from '@/lib/apiError'
 
 import { getUserRsvps } from '@/app/actions/db/sessionRsvps'
+import { getApiUser, unauthorizedResponse } from '@/app/api/apiAuth'
 
 import { DbSessionRsvp } from '@/types/database/dbTypeAliases'
 
@@ -13,6 +14,10 @@ export async function GET(
   { params }: { params: Promise<{ userId: string }> },
 ) {
   try {
+    // Another attendee's schedule, so attendees only
+    const user = await getApiUser()
+    if (!user) return unauthorizedResponse()
+
     const { userId } = await params
 
     const rsvps = await getUserRsvps({ userId })

--- a/app/api/queries/rsvps/route.ts
+++ b/app/api/queries/rsvps/route.ts
@@ -3,12 +3,17 @@ import { NextResponse } from 'next/server'
 import { apiError } from '@/lib/apiError'
 
 import { getAllRsvps } from '@/app/actions/db/sessionRsvps'
+import { getApiUser, unauthorizedResponse } from '@/app/api/apiAuth'
 
 import { DbFullSessionRsvp } from '@/types/database/dbTypeAliases'
 
 export type ApiRsvpsResponse = DbFullSessionRsvp[]
 export async function GET() {
   try {
+    // Names every attendee of every session, so attendees only
+    const user = await getApiUser()
+    if (!user) return unauthorizedResponse()
+
     const rsvps = await getAllRsvps()
 
     return NextResponse.json(rsvps satisfies ApiRsvpsResponse)

--- a/app/api/queries/session-bookmarks/[userId]/route.ts
+++ b/app/api/queries/session-bookmarks/[userId]/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { apiError } from '@/lib/apiError'
 
 import { getUserSessionBookmarks } from '@/app/actions/db/sessionBookmarks'
+import { getApiUser, unauthorizedResponse } from '@/app/api/apiAuth'
 
 import { DbSessionBookmark } from '@/types/database/dbTypeAliases'
 
@@ -12,6 +13,10 @@ export async function GET(
   { params }: { params: Promise<{ userId: string }> },
 ) {
   try {
+    // Another attendee's saved sessions, so attendees only
+    const user = await getApiUser()
+    if (!user) return unauthorizedResponse()
+
     const { userId } = await params
     const bookmarks = await getUserSessionBookmarks({ userId })
 

--- a/app/api/queries/session-bookmarks/route.ts
+++ b/app/api/queries/session-bookmarks/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { apiError } from '@/lib/apiError'
 
 import { getAllSessionBookmarks } from '@/app/actions/db/sessionBookmarks'
+import { getApiUser, unauthorizedResponse } from '@/app/api/apiAuth'
 
 import { DbSessionBookmark } from '@/types/database/dbTypeAliases'
 
@@ -10,6 +11,10 @@ export type ApiAllSessionBookmarksResponse = DbSessionBookmark[]
 
 export async function GET() {
   try {
+    // Maps every attendee to the sessions they are interested in, so attendees only
+    const user = await getApiUser()
+    if (!user) return unauthorizedResponse()
+
     const bookmarks = await getAllSessionBookmarks()
 
     return NextResponse.json(bookmarks satisfies ApiAllSessionBookmarksResponse)

--- a/app/api/queries/sessions/[id]/route.ts
+++ b/app/api/queries/sessions/[id]/route.ts
@@ -2,7 +2,10 @@ import { NextResponse } from 'next/server'
 
 import { apiError } from '@/lib/apiError'
 
+import { sessionWithoutAttendees } from '@/utils/dbUtils'
+
 import { getSessionById } from '@/app/actions/db/sessions'
+import { getApiUser } from '@/app/api/apiAuth'
 
 import { DbFullSession } from '@/types/database/dbTypeAliases'
 
@@ -12,9 +15,14 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const session = await getSessionById({ sessionId: (await params).id })
+    // The session itself is public; who is going to it is not
+    const user = await getApiUser()
 
-    return NextResponse.json(session satisfies ApiSessionResponse)
+    const session = await getSessionById({ sessionId: (await params).id })
+    const visibleSession =
+      session && !user ? sessionWithoutAttendees(session) : session
+
+    return NextResponse.json(visibleSession satisfies ApiSessionResponse)
   } catch (error) {
     return apiError(error, 'Failed to fetch session')
   }

--- a/app/api/queries/sessions/route.ts
+++ b/app/api/queries/sessions/route.ts
@@ -2,16 +2,25 @@ import { NextResponse } from 'next/server'
 
 import { apiError } from '@/lib/apiError'
 
+import { sessionWithoutAttendees } from '@/utils/dbUtils'
+
 import { getAllSessions } from '@/app/actions/db/sessions'
+import { getApiUser } from '@/app/api/apiAuth'
 
 import { DbFullSession } from '@/types/database/dbTypeAliases'
 
 export type ApiAllSessionsResponse = DbFullSession[]
 export async function GET() {
   try {
-    const sessions = await getAllSessions()
+    // The schedule itself is public; who is going to each session is not
+    const user = await getApiUser()
 
-    return NextResponse.json(sessions satisfies ApiAllSessionsResponse)
+    const sessions = await getAllSessions()
+    const visibleSessions = user
+      ? sessions
+      : sessions.map(sessionWithoutAttendees)
+
+    return NextResponse.json(visibleSessions satisfies ApiAllSessionsResponse)
   } catch (error) {
     return apiError(error, 'Failed to fetch sessions')
   }

--- a/lib/profiles.ts
+++ b/lib/profiles.ts
@@ -1,6 +1,23 @@
 import { ProfileFormData } from './schemas/profile'
 
-import { DbFullProfile } from '@/types/database/dbTypeAliases'
+import { DbFullProfile, DbPublicProfile } from '@/types/database/dbTypeAliases'
+
+/** Public profiles are served to anonymous callers, so drop the fields that are
+ * only meant for signed-in attendees. Redacting here rather than in the db
+ * projection keeps `is_admin` available to the server-side auth checks in
+ * utils/security, which read it off the public profile. */
+export const stripPrivateProfileFields = (
+  profile: DbPublicProfile,
+): DbPublicProfile => {
+  const {
+    discord_handle: _discord_handle,
+    is_admin: _is_admin,
+    minor: _minor,
+    checked_in: _checked_in,
+    ...publicFields
+  } = profile
+  return publicFields
+}
 
 export const requiredProfileFields: (keyof ProfileFormData)[] = [
   'first_name',

--- a/types/database/dbTypeAliases.ts
+++ b/types/database/dbTypeAliases.ts
@@ -47,26 +47,30 @@ export type DbPublicProfileKeys =
   | 'first_name'
   | 'last_name'
   | 'team'
-  | 'discord_handle'
   | 'opted_in_to_homepage_display'
   | 'bio'
-  | 'is_admin'
   | 'homepage_order'
   | 'site_name'
   | 'site_url'
   | 'site_name_2'
   | 'site_url_2'
   | 'dismissed_info_request'
-  | 'minor'
   | 'profile_pictures_url'
   | 'player_id'
   | 'pronouns'
   | 'volunteer'
-  | 'checked_in'
   | 'celestial_card_id'
-export type DbPublicProfile = Pick<DbFullProfile, DbPublicProfileKeys> & {
-  celestial_card: DbCelestialCard | null
-}
+/** Fields of the public profile projection that only signed-in callers get: the
+ * API strips them for anonymous requests, so they are optional on every reader. */
+export type DbPrivateProfileKeys =
+  | 'discord_handle'
+  | 'is_admin'
+  | 'minor'
+  | 'checked_in'
+export type DbPublicProfile = Pick<DbFullProfile, DbPublicProfileKeys> &
+  Partial<Pick<DbFullProfile, DbPrivateProfileKeys>> & {
+    celestial_card: DbCelestialCard | null
+  }
 export type DbProfileInsert = TablesInsert<'profiles'>
 export type DbProfileUpdate = TablesUpdate<'profiles'>
 export type DbTeamColor = Enums<'TEAM_COLORS'>

--- a/utils/dbUtils.ts
+++ b/utils/dbUtils.ts
@@ -73,6 +73,16 @@ export const SESSION_CATEGORIES_ENUM = Object.values(
   SESSION_CATEGORIES,
 ) as DbSessionCategory[]
 
+/** A session with the attendee lists removed. RSVP rows carry attendee names and
+ * user ids and bookmarks carry user ids, so anonymous callers get neither. */
+export const sessionWithoutAttendees = (
+  session: DbFullSession,
+): DbFullSession => ({
+  ...session,
+  rsvps: [],
+  bookmarks: [],
+})
+
 export const countRsvpsByTeamColor = (
   rsvps: Pick<DbFullSessionRsvp, 'user'>[],
 ) => {


### PR DESCRIPTION
Locks down the `/api/queries/**` tree: routes that only serve attendee data now require a session, and the routes the public site genuinely needs stay open but redact the attendee-identifying parts for anonymous callers.

- **401 without a session**: `profiles/public` (GET, whole roster), `rsvps`, `rsvps/[userId]`, `session-bookmarks`, `session-bookmarks/[userId]`. Nothing in the app fetches these while logged out (the roster GET has no caller at all — every grid uses the POST-by-ids form).
- **Still public, but redacted for anonymous callers**: `sessions`, `sessions/[id]` drop `rsvps` and `bookmarks` (both carry attendee ids, RSVPs carry names); `profiles/public` POST and `profiles/public/[userId]` drop `discord_handle`, `is_admin`, `minor`, `checked_in`.
- Dropped `Cache-Control: public, s-maxage=300` from the public-profile routes — the response varies by session now, so it can't sit in a shared cache.
- Shared helpers so the check is one line per route: `getApiUser()` / `unauthorizedResponse()` in `app/api/apiAuth.ts`, `stripPrivateProfileFields()` in `lib/profiles.ts`, `sessionWithoutAttendees()` in `utils/dbUtils.ts`.
- `DbPublicProfile` now marks the four private fields optional (`DbPrivateProfileKeys`), which is what lets one response type cover both the redacted and full shapes.

### Where I deviated from the issue

The issue says to drop the four fields from `publicProfileSelectIncludes`. **Removing `is_admin` there would have silently broken every server-side auth check**: `utils/security.ts` `profileAuthLevel()` reads `is_admin` off the profile returned by `getUserPublicProfileById()`, so admins would have quietly degraded to GREEN/VOLUNTEER/NONE. `minor` and `discord_handle` are also rendered on player cards, which signed-in attendees should still see. So the db projection is unchanged and the redaction happens at the API boundary instead, where the audience is known.

The issue also lists `sessions` as needing a session check. `/schedule` is a public page, so that would have taken the schedule offline for logged-out visitors; stripping the attendee lists gets the same privacy result.

## Testing required

Preview URL, then:

1. **Logged out — public pages still work.**
   - `/` — the speakers grid renders real cards (names, photos, bios, sites). A wall of gray "Loading…"/"Error" frames means the POST profiles route broke.
   - `/player/1234` (any real 4-digit player id) — card renders. Two intended changes here: no Discord handle at the bottom of the card, and no 🌱 next to a minor's name.
   - `/schedule` — sessions, times, locations, hosts all render. Intended changes: the attendee tooltip (hover the person icon on a session) is now empty, and megagame sessions show `0/N` team counts instead of real ones. Titles/times/locations disappearing = regression.
2. **Logged in — nothing lost.**
   - `/schedule` — RSVP counts, the attendee name list in the tooltip, your bookmarks and RSVPs all behave as before. Un-RSVP (green/admin) still works.
   - `/player/<your id>` — Discord handle is back on the card.
   - `/profile` loads.
3. **curl, logged out** (should all be `401 {"error":"Unauthorized"}`):
   ```
   PREVIEW=https://metagame-2025-git-meta-397-api-auth-arbor-metagame.vercel.app
   curl -si "$PREVIEW/api/queries/profiles/public" | head -1
   curl -si "$PREVIEW/api/queries/rsvps" | head -1
   curl -si "$PREVIEW/api/queries/session-bookmarks" | head -1
   ```
   And these should be `200` with the data redacted — check that `minor`, `discord_handle`, `is_admin`, `checked_in` are **absent** and that `rsvps`/`bookmarks` are `[]`:
   ```
   curl -s "$PREVIEW/api/queries/profiles/public/<user-uuid>" | jq
   curl -s "$PREVIEW/api/queries/sessions" | jq '.[0] | {rsvps, bookmarks}'
   curl -s -X POST "$PREVIEW/api/queries/profiles/public" -d '{"userIds":["<user-uuid>"]}' | jq
   ```
   Also confirm the response header is `Cache-Control: private, no-store`, not `public, s-maxage=300`.
4. **curl, logged in.** Copy the `sb-*-auth-token` cookies from a signed-in browser session (DevTools → Application → Cookies) and repeat with `--cookie`. The 401 routes should return data, and `/api/queries/profiles/public/<uuid>` should now include `minor`/`discord_handle`.

Note the preview is Vercel-protection-gated, so opening it needs a Vercel seat.

### Cannot be checked from the preview

- **CDN cache purge (production, after merge).** `/api/queries/profiles/public` and `/api/queries/profiles/public/[userId]` have been served with `s-maxage=300, stale-while-revalidate=86400` for a long time, so the un-redacted roster may still be sitting in Vercel's edge cache for up to a day after deploy. Purge the data cache / redeploy with cache invalidation once this is live, and re-run the logged-out curls against `2025.metagame.games` to confirm.
- **Admin-only paths** (`/admin/tools/*`, `/checkin`) hit `/api/queries/profiles` (full profiles, admin-wrapped, untouched here) — worth one smoke pass with an admin account since they share the profile types.

## Noticed but out of scope

- **Server actions are a parallel, unguarded path to the same data.** `getAllRsvps`, `getAllSessions`, `getAllSessionBookmarks`, `getAllUserPublicProfiles` etc. are re-exported unwrapped from `app/actions/db/*` under `'use server'`, which makes each of them an RPC endpoint any client can invoke — bypassing the route checks added here. Fixing that needs a "requires a session" wrapper alongside `adminExportWrapper`/`currentUserWrapper`. Probably its own subissue, and arguably the more important half of META-397.
- The issue's claim that "the UI deliberately hides even the RSVP count from logged-out users" is only half right: the count is hidden, but `RSVPList`'s tooltip rendered the full attendee name list to anyone. This PR fixes that as a side effect (empty list for anonymous callers).
- Zero RLS policies exist, so everything runs through the service client. Unchanged here, but it means route/action-level checks are the only access control.
- `POST /api/queries/profiles/public` doesn't validate its body — a missing/oddly-typed `userIds` becomes a 500.
- Catch blocks in these files still leak stack traces; left alone for META-408.

Static verification only — no local install/build on this box, so CI and the preview deploy are the first real checks.
