### PR TITLE
Fix schedule correctness: host edits blocked, sessions silently dropped [META-403]

### DIFF
--- a/app/schedule/EditEventModal.tsx
+++ b/app/schedule/EditEventModal.tsx
@@ -88,7 +88,7 @@ export function AddEventModal({
     title: '',
     description: '',
     needs: '',
-    day: defaultDay || CONFERENCE_DAYS[0].date.getDate().toString(),
+    day: defaultDay || dateUtils.getPacificParts(CONFERENCE_DAYS[0].date).day,
     startTime: '09:00',
     endTime: '09:30',
     minCapacity: null,
@@ -606,14 +606,17 @@ export function AddEventModal({
                     <SelectValue placeholder="Select a day" />
                   </SelectTrigger>
                   <SelectContent className="z-[70]">
-                    {CONFERENCE_DAYS.map((day) => (
-                      <SelectItem
-                        key={day.date.getDate().toString()}
-                        value={day.date.getDate().toString()}
-                      >
-                        {day.name}
-                      </SelectItem>
-                    ))}
+                    {CONFERENCE_DAYS.map((day) => {
+                      // Pacific day-of-month, not local getDate(): a viewer in
+                      // a timezone west of Pacific would otherwise get the
+                      // previous calendar day
+                      const dayValue = dateUtils.getPacificParts(day.date).day
+                      return (
+                        <SelectItem key={dayValue} value={dayValue}>
+                          {day.name}
+                        </SelectItem>
+                      )
+                    })}
                   </SelectContent>
                 </Select>
               </div>

--- a/app/schedule/Schedule.tsx
+++ b/app/schedule/Schedule.tsx
@@ -40,8 +40,10 @@ import { useScheduleStuff } from '@/hooks/schedule/useScheduleStuff'
 import { useUser } from '@/hooks/useUser'
 import { DbFullSession } from '@/types/database/dbTypeAliases'
 
-const SCHEDULE_START_TIMES = [14, 9, 9]
-const SCHEDULE_END_TIMES = [22, 22, 22]
+// Baseline display window per day; extended when sessions fall outside it
+const DEFAULT_START_HOURS = [14, 9, 9]
+const DEFAULT_END_HOURS = [22, 22, 22]
+const MINUTES_PER_DAY = 24 * 60
 // Fixed conference days - create Date objects representing midnight in Pacific Time
 export const CONFERENCE_DAYS = [
   { date: new Date('2025-09-12T00:00:00-07:00'), name: 'Friday' },
@@ -49,55 +51,38 @@ export const CONFERENCE_DAYS = [
   { date: new Date('2025-09-14T00:00:00-07:00'), name: 'Sunday' },
 ]
 
-// Generate time slots from 9:00 to 22:00 in 30-minute intervals
-const generateTimeSlots = (dayIndex: number) => {
-  const slots = []
-  for (
-    let hour = SCHEDULE_START_TIMES[dayIndex];
-    hour <= SCHEDULE_END_TIMES[dayIndex];
-    hour++
-  ) {
+// A session placed on the grid, with its Pacific-midnight-relative position
+// computed once instead of per slot x location render
+type PlacedSession = {
+  session: DbFullSession
+  startMinutes: number
+  durationMinutes: number
+}
+
+// Generate 30-minute slots covering [startHour, endHour]
+const generateTimeSlots = (startHour: number, endHour: number) => {
+  const slots: string[] = []
+  for (let hour = startHour; hour <= endHour; hour++) {
     slots.push(`${hour.toString().padStart(2, '0')}:00`)
-    if (hour < SCHEDULE_END_TIMES[dayIndex]) {
+    if (hour < endHour) {
       slots.push(`${hour.toString().padStart(2, '0')}:30`)
     }
   }
   return slots
 }
 
-// Updated slot checking - PST based
-const eventStartsInSlot = (session: DbFullSession, slotTime: string) => {
-  if (!session.start_time) return false
+const slotForMinutes = (minutes: number) => {
+  const hour = Math.floor(minutes / 60)
+  return `${hour.toString().padStart(2, '0')}:${minutes % 60 >= 30 ? '30' : '00'}`
+}
 
-  const sessionStartMinutes = dateUtils.getPSTMinutes(session.start_time)
-  const [slotHour, slotMinute] = slotTime.split(':').map(Number)
-  const slotStartMinutes = slotHour * 60 + slotMinute
-  const slotEndMinutes = slotStartMinutes + 30
-
-  return (
-    sessionStartMinutes >= slotStartMinutes &&
-    sessionStartMinutes < slotEndMinutes
+// Default to the conference day in progress (Pacific) when there is one
+const getDefaultDayIndex = () => {
+  const todayKey = dateUtils.getYYYYMMDD(new Date())
+  const todayIndex = CONFERENCE_DAYS.findIndex(
+    (day) => dateUtils.getYYYYMMDD(day.date) === todayKey,
   )
-}
-
-// Updated offset calculation - PST based
-const getEventOffsetMinutes = (session: DbFullSession, slotTime: string) => {
-  if (!session.start_time) return 0
-
-  const sessionStartMinutes = dateUtils.getPSTMinutes(session.start_time)
-  const [slotHour, slotMinute] = slotTime.split(':').map(Number)
-  const slotStartMinutes = slotHour * 60 + slotMinute
-
-  return Math.max(0, sessionStartMinutes - slotStartMinutes)
-}
-
-// Updated duration calculation - PST based
-const getEventDurationMinutes = (session: DbFullSession) => {
-  if (!session.start_time || !session.end_time) return 30
-
-  const startMinutes = dateUtils.getPSTMinutes(session.start_time)
-  const endMinutes = dateUtils.getPSTMinutes(session.end_time)
-  return endMinutes - startMinutes
+  return todayIndex >= 0 ? todayIndex : 0
 }
 
 export default function Schedule({
@@ -174,11 +159,13 @@ export default function Schedule({
 
   // Group sessions by the 3 fixed conference days
   const days = useMemo(() => {
-    const dayEvents = [
-      [], // Day 0: Friday 9/12
-      [], // Day 1: Saturday 9/13
-      [], // Day 2: Sunday 9/14
-    ] as DbFullSession[][]
+    // Compare full Pacific dates, not just day-of-month, so a stray
+    // out-of-September session can't land on the wrong day
+    const dayKeys = CONFERENCE_DAYS.map((day) => dateUtils.getYYYYMMDD(day.date))
+    const schedulableLocationIds = new Set(
+      allScheduleLocations.map((location) => location.id),
+    )
+    const dayEvents = CONFERENCE_DAYS.map(() => [] as DbFullSession[])
 
     const userRsvpOrHostingSession = (session: DbFullSession) => {
       if (!currentUserProfile) return true
@@ -200,38 +187,88 @@ export default function Schedule({
         )
       : sessions
     filteredSessions.forEach((session) => {
-      const [sessionStart, sessionEnd] = [
-        session.start_time,
-        session.end_time,
-      ].filter(Boolean)
-      if (!sessionStart || !sessionEnd || !session.title) return
+      if (!session.start_time || !session.end_time || !session.title) return
 
-      const dayIndex = CONFERENCE_DAYS.findIndex((day) => {
-        if (
-          dateUtils.getPacificParts(day.date).day ===
-          dateUtils.getPacificParts(new Date(sessionStart)).day
-        ) {
-          return true
-        }
-        return false
-      })
+      const dayIndex = dayKeys.indexOf(
+        dateUtils.getYYYYMMDD(new Date(session.start_time)),
+      )
       if (dayIndex >= 0) {
         dayEvents[dayIndex].push(session)
+      } else {
+        console.warn(
+          `Session "${session.title}" (${session.id}) starts at ${session.start_time}, outside the conference days — not displayed`,
+        )
       }
     })
 
     // Create the final days array
-    return CONFERENCE_DAYS.map((confDay, index) => ({
-      date: confDay.date,
-      displayName: `${confDay.name} (${dateUtils.getYYYYMMDD(confDay.date)})`,
-      shortDateDisplayName: `${confDay.name} (${dateUtils.getYYYYMMDD(confDay.date).slice(5)})`,
-      shortName: confDay.name,
-      events: dayEvents[index].sort((a, b) =>
+    return CONFERENCE_DAYS.map((confDay, index) => {
+      const events = dayEvents[index].sort((a, b) =>
         (a.start_time || '').localeCompare(b.start_time || ''),
-      ),
-    }))
-  }, [sessions, filterForUserEvents, bookmarks])
-  const [currentDayIndex, setCurrentDayIndex] = useState(dayIndex ?? 2)
+      )
+
+      // Derive the day's window from its sessions so nothing falls off the
+      // grid, keeping the default window as a floor
+      let startHour = DEFAULT_START_HOURS[index]
+      let endHour = DEFAULT_END_HOURS[index]
+      const placed: PlacedSession[] = []
+      const unscheduled: DbFullSession[] = []
+
+      events.forEach((session) => {
+        if (
+          !session.location_id ||
+          !schedulableLocationIds.has(session.location_id)
+        ) {
+          unscheduled.push(session)
+          return
+        }
+        const startMinutes = dateUtils.getPSTMinutes(session.start_time!)
+        const trueDurationMinutes =
+          (new Date(session.end_time!).getTime() -
+            new Date(session.start_time!).getTime()) /
+          60000
+        // Clamp: at least 15 so the block stays clickable, and cut off at the
+        // day's midnight since each grid only spans one day
+        const durationMinutes = Math.max(
+          15,
+          Math.min(trueDurationMinutes, MINUTES_PER_DAY - startMinutes),
+        )
+        startHour = Math.min(startHour, Math.floor(startMinutes / 60))
+        endHour = Math.max(
+          endHour,
+          Math.min(24, Math.ceil((startMinutes + durationMinutes) / 60)),
+        )
+        placed.push({ session, startMinutes, durationMinutes })
+      })
+
+      // Bucket once per day instead of filtering every slot x location on render
+      const grid = new Map<string, Map<string, PlacedSession[]>>()
+      placed.forEach((entry) => {
+        const locationId = entry.session.location_id!
+        const slot = slotForMinutes(entry.startMinutes)
+        const locationSlots =
+          grid.get(locationId) ?? new Map<string, PlacedSession[]>()
+        locationSlots.set(slot, [...(locationSlots.get(slot) ?? []), entry])
+        grid.set(locationId, locationSlots)
+      })
+
+      return {
+        date: confDay.date,
+        displayName: `${confDay.name} (${dateUtils.getYYYYMMDD(confDay.date)})`,
+        shortDateDisplayName: `${confDay.name} (${dateUtils.getYYYYMMDD(confDay.date).slice(5)})`,
+        shortName: confDay.name,
+        events,
+        startHour,
+        endHour,
+        slots: generateTimeSlots(startHour, endHour),
+        grid,
+        unscheduled,
+      }
+    })
+  }, [sessions, filterForUserEvents, bookmarks, allScheduleLocations])
+  const [currentDayIndex, setCurrentDayIndex] = useState(
+    () => dayIndex ?? getDefaultDayIndex(),
+  )
   const [openedSessionId, setOpenedSessionId] = useState<
     DbFullSession['id'] | null
   >(sessionId ?? null)
@@ -246,27 +283,20 @@ export default function Schedule({
     return sessions.find((s) => s.id === openedSessionId) ?? null
   }, [sessions, openedSessionId])
 
-  // Sync URL parameters with state changes
+  // Sync URL parameters with state changes. Always write `day` — a guard like
+  // "skip the default" makes links to the default day not survive a reload
   useEffect(() => {
     if (!pathname.startsWith('/schedule')) return
     const params = new URLSearchParams()
-    if (currentDayIndex !== 0) params.set('day', currentDayIndex.toString())
+    params.set('day', currentDayIndex.toString())
     if (openedSessionId) params.set('session', openedSessionId)
-    if (!openedSessionId) params.delete('session')
     if (locationFilter?.length)
       params.set('locations', locationFilter.join(','))
 
-    const newUrl = params.toString()
-      ? `?${params.toString()}`
-      : window.location.pathname
-    router.replace(newUrl, { scroll: false })
-  }, [currentDayIndex, openedSessionId, locationFilter, router])
+    router.replace(`?${params.toString()}`, { scroll: false })
+  }, [currentDayIndex, openedSessionId, locationFilter, router, pathname])
 
-  const currentDay = days[currentDayIndex] || {
-    date: '',
-    displayName: 'No Events',
-    events: [],
-  }
+  const currentDay = days[currentDayIndex] || days[0]
 
   const nextDay = () => {
     setCurrentDayIndex((prev) => Math.min(days.length - 1, prev + 1))
@@ -329,23 +359,17 @@ export default function Schedule({
   // Calculate current time position for the red line
   const getCurrentTimePosition = () => {
     const now = new Date()
-    const currentDay = CONFERENCE_DAYS[currentDayIndex]
 
     // Check if current day matches the selected day
-    const todayParts = dateUtils.getPacificParts(now)
-    const selectedDayParts = dateUtils.getPacificParts(currentDay.date)
-
     if (
-      todayParts.day !== selectedDayParts.day ||
-      todayParts.month !== selectedDayParts.month ||
-      todayParts.year !== selectedDayParts.year
+      dateUtils.getYYYYMMDD(now) !== dateUtils.getYYYYMMDD(currentDay.date)
     ) {
       return null // Not today, don't show the line
     }
 
     const currentMinutes = dateUtils.getPSTMinutes(now.toISOString())
-    const startMinutes = SCHEDULE_START_TIMES[currentDayIndex] * 60
-    const endMinutes = SCHEDULE_END_TIMES[currentDayIndex] * 60
+    const startMinutes = currentDay.startHour * 60
+    const endMinutes = currentDay.endHour * 60
 
     // Only show if within schedule hours
     if (currentMinutes < startMinutes || currentMinutes > endMinutes) {
@@ -528,7 +552,7 @@ export default function Schedule({
             className={`relative grid w-fit bg-dark-400 ${scheduleLocations.length === 0 ? 'hidden' : ''}`}
             style={{ gridTemplateColumns }}
           >
-            {generateTimeSlots(currentDayIndex).map((time) => (
+            {currentDay.slots.map((time) => (
               <div key={time} className="contents">
                 {/* Time Cell - Sticky Left */}
                 <div className="sticky top-0 left-0 z-sticky flex w-full justify-center border border-dark-400 border-r-secondary-300 bg-dark-500">
@@ -539,17 +563,15 @@ export default function Schedule({
 
                 {/* Venue Cells */}
                 {scheduleLocations.map((venue) => {
-                  const eventsInSlot = currentDay.events.filter(
-                    (session) =>
-                      session.location_id === venue.id &&
-                      eventStartsInSlot(session, time),
-                  )
+                  const eventsInSlot =
+                    currentDay.grid.get(venue.id)?.get(time) ?? []
                   return (
                     <div
                       key={venue.id}
                       className="relative min-h-[60px] overflow-visible border border-dark-400 bg-dark-500"
                     >
-                      {eventsInSlot.map((session) => (
+                      {eventsInSlot.map(
+                        ({ session, startMinutes, durationMinutes }, index) => (
                         <SessionTooltip
                           key={session.id}
                           tooltip={
@@ -564,10 +586,12 @@ export default function Schedule({
                             onClick={() => handleOpenSessionModal(session.id!)}
                             className={`group absolute z-content m-0.5 cursor-pointer rounded-md border-2 p-1 ${getEventColor(session)} font-semibold text-black`}
                             style={{
-                              top: `${getEventOffsetMinutes(session, time) * 2}px`, // 2px per minute
-                              height: `${getEventDurationMinutes(session) * 2}px`, // 2px per minute
-                              left: '0px',
-                              right: '0px',
+                              top: `${(startMinutes % 30) * 2}px`, // 2px per minute
+                              height: `${durationMinutes * 2}px`, // 2px per minute
+                              // Double-booked slots share the cell side by side
+                              // instead of stacking invisibly on top of each other
+                              left: `${(index * 100) / eventsInSlot.length}%`,
+                              width: `calc(${100 / eventsInSlot.length}% - 4px)`,
                               boxShadow: isUserRsvpd(session.id!)
                                 ? '0 0 0 3px #ff33be'
                                 : undefined,
@@ -682,12 +706,7 @@ export default function Schedule({
               >
                 {/* Time label on the left */}
                 <div className="absolute top-[-12px] left-2 rounded bg-red-600 px-1 py-0.5 text-xs font-medium text-white shadow-lg">
-                  {new Intl.DateTimeFormat('en-US', {
-                    timeZone: 'America/Los_Angeles',
-                    hour: '2-digit',
-                    minute: '2-digit',
-                    hour12: false,
-                  }).format(new Date())}
+                  {dateUtils.getStringTime(new Date().toISOString())}
                 </div>
               </div>
             )}
@@ -698,6 +717,32 @@ export default function Schedule({
       {scheduleLocations.length === 0 && (
         <div className="w-full p-8 text-center text-sm text-secondary-300">
           No locations selected — pick some from the filter menu.
+        </div>
+      )}
+
+      {/* Sessions this day that have no schedulable location — surfaced here
+          instead of silently dropped from the grid */}
+      {currentDay.unscheduled.length > 0 && (
+        <div className="w-full border-t border-secondary-300 p-4">
+          <h3 className="mb-2 text-sm font-semibold text-secondary-300">
+            Location TBD
+          </h3>
+          <div className="flex flex-wrap gap-2">
+            {currentDay.unscheduled.map((session) => (
+              <button
+                key={session.id}
+                onClick={() => handleOpenSessionModal(session.id!)}
+                className={`cursor-pointer rounded-md border-2 p-2 text-left text-sm font-semibold text-black ${getEventColor(session)}`}
+              >
+                <SessionTitle title={session.title} />
+                <div className="font-sans text-xs font-normal">
+                  {dateUtils.getStringTime(session.start_time!)}
+                  {session.end_time &&
+                    ` - ${dateUtils.getStringTime(session.end_time)}`}
+                </div>
+              </button>
+            ))}
+          </div>
         </div>
       )}
 

--- a/app/schedule/actions.ts
+++ b/app/schedule/actions.ts
@@ -5,7 +5,7 @@ import z from 'zod'
 import { sessionsService } from '@/lib/db/sessions'
 import { usersService } from '@/lib/db/users'
 
-import { SESSION_AGES } from '@/utils/dbUtils'
+import { SESSION_AGES, SESSION_CATEGORIES } from '@/utils/dbUtils'
 import { createClient } from '@/utils/supabase/server'
 
 import { DbSession, DbSessionUpdate } from '@/types/database/dbTypeAliases'
@@ -41,9 +41,11 @@ const sessionUpdateSchema = z.object({
   title: z.string().min(1).optional(),
   description: z.string().optional().nullable(),
   needs: z.string().optional().nullable(),
-  min_capacity: z.number().min(1).optional(),
-  max_capacity: z.number().min(1).optional(),
+  // nullish, not optional: the edit modal sends explicit nulls for unset capacities
+  min_capacity: z.number().min(1).nullish(),
+  max_capacity: z.number().min(1).nullish(),
   ages: z.enum(SESSION_AGES).optional(),
+  category: z.enum(SESSION_CATEGORIES).nullish(),
 })
 export async function userEditSession({
   sessionId,

--- a/utils/dateUtils.ts
+++ b/utils/dateUtils.ts
@@ -1,3 +1,45 @@
+// Hoisted formatters: constructing Intl.DateTimeFormat is expensive and these
+// run in render-hot paths (the schedule grid calls getPacificParts per session)
+const YMD_PACIFIC = new Intl.DateTimeFormat('en-CA', {
+  timeZone: 'America/Los_Angeles',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+})
+
+const PARTS_PACIFIC = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/Los_Angeles',
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  weekday: 'long',
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: false,
+})
+
+const LONG_DATE_PACIFIC = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/Los_Angeles',
+  weekday: 'long',
+  month: 'long',
+  day: 'numeric',
+  year: 'numeric',
+})
+
+const OFFSET_PACIFIC = new Intl.DateTimeFormat('en-US', {
+  timeZone: 'America/Los_Angeles',
+  timeZoneName: 'longOffset',
+})
+
+/** Pacific UTC offset in whole hours (-7 during PDT, -8 during PST) at the given instant */
+const pacificOffsetHours = (date: Date) => {
+  const offsetName = OFFSET_PACIFIC.formatToParts(date).find(
+    (part) => part.type === 'timeZoneName',
+  )?.value // e.g. "GMT-07:00"
+  const match = offsetName?.match(/GMT([+-]\d{1,2})/)
+  return match ? Number(match[1]) : -8
+}
+
 export const dateUtils = {
   /** e.g. "2025-08-14T16:00:00.000Z" -> "2025-08-14T09:00:00.000Z" */
   stringTimestampToPSTString: (timestamp: string) => {
@@ -12,9 +54,9 @@ export const dateUtils = {
     const parts = dateUtils.getPacificParts(date)
     return Number(parts.hour) * 60 + Number(parts.minute)
   },
+  /** e.g. "Friday, September 12, 2025" */
   getStringDate: (timestamp: string) => {
-    const parts = dateUtils.getPacificParts(new Date(timestamp))
-    return `${parts.weekday}, ${parts.month} ${parts.day}, ${parts.year}`
+    return LONG_DATE_PACIFIC.format(new Date(timestamp))
   },
   getStringTime: (timestamp: string) => {
     const parts = dateUtils.getPacificParts(new Date(timestamp))
@@ -27,16 +69,7 @@ export const dateUtils = {
 
   /** e.g. day: "14", hour: "20", minute: "36", month: "08", weekday: "Thu", year: "2025" */
   getPacificParts: (date: Date) => {
-    const parts = new Intl.DateTimeFormat('en-US', {
-      timeZone: 'America/Los_Angeles',
-      year: 'numeric',
-      month: '2-digit',
-      day: '2-digit',
-      weekday: 'long',
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: false,
-    }).formatToParts(date)
+    const parts = PARTS_PACIFIC.formatToParts(date)
 
     // Turn into a simple object { year, month, day, weekday, hour, minute }
     return Object.fromEntries(
@@ -53,7 +86,7 @@ export const dateUtils = {
     minute?: number | string
     timezone?: number | string // hours from UTC, e.g. -7
   }) => {
-    const { year, month, day, time, hour, minute, timezone = -7 } = parts
+    const { year, month, day, time, hour, minute, timezone } = parts
 
     const [h, m] = time
       ? time.split(':').map(Number)
@@ -62,16 +95,18 @@ export const dateUtils = {
     const y = Number(year)
     const mo = Number(month) - 1 // Month is 0-indexed
     const d = Number(day)
-    const tz = Number(timezone)
-    console.log(tz)
+    // Derive the Pacific offset for the target date rather than hardcoding -7,
+    // which is only correct during PDT
+    const tz =
+      timezone !== undefined
+        ? Number(timezone)
+        : pacificOffsetHours(new Date(Date.UTC(y, mo, d, 12)))
     const tzString =
       tz >= 0
         ? `+${tz.toString().padStart(2, '0')}:00`
         : `-${Math.abs(tz).toString().padStart(2, '0')}:00`
     // Create a date string in ISO format
-    console.log('tzString', tzString)
     const dateString = `${y.toString().padStart(4, '0')}-${(mo + 1).toString().padStart(2, '0')}-${d.toString().padStart(2, '0')}T${h.toString().padStart(2, '0')}:${m.toString().padStart(2, '0')}${tzString}`
-    console.log('dateString', dateString)
     // Create a date and interpret it as Pacific time
     return new Date(dateString)
   },
@@ -118,10 +153,3 @@ export const dateUtils = {
     })
   },
 }
-
-const YMD_PACIFIC = new Intl.DateTimeFormat('en-CA', {
-  timeZone: 'America/Los_Angeles',
-  year: 'numeric',
-  month: '2-digit',
-  day: '2-digit',
-})


### PR DESCRIPTION
Fixes the six schedule correctness bugs from META-403: non-admin host edits failing Zod validation, sessions silently vanishing from the grid, midnight-crossing breakage, malformed dates, invisible double-bookings, and the wrong default day. Also absorbs the schedule-render perf item from META-405 (formatter hoisting + slot precomputation), since it lives in exactly the code this restructures.

## Per bug

1. **Host edits blocked** — `min_capacity`/`max_capacity` are now `.nullish()` (the modal sends explicit `null`s), and `category` was added to `sessionUpdateSchema` so a host's category pick persists instead of being silently stripped (`app/schedule/actions.ts`).
2. **Sessions outside the hardcoded window vanish** — each day's grid window is now derived from its sessions' actual start/end times, with the old 14/9/9–22 hours kept as a floor so quiet days don't collapse. Sessions with no location (or a location hidden from the schedule) render in a "Location TBD" tray below the grid instead of disappearing.
3. **Midnight-crossing sessions** — duration is computed from timestamps (no more negative heights), clamped to ≥15 min and cut at the day's midnight since each grid spans one day. Day bucketing compares full Pacific dates via `getYYYYMMDD`, not day-of-month, so a 00:30 Sept 13 session files under Saturday and a stray Oct 13 event matches no day (it logs a `console.warn` rather than rendering — it has no tab to live on). The hardcoded `timezone = -7` default in `dateFromParts` is replaced with an offset derived from the target date (verified: Sept 2025 → -7, Jan 2026 → -8); also removed that function's leftover `console.log`s.
4. **"Friday, 09 12, 2025"** — `getStringDate` now uses a dedicated long-form formatter → "Friday, September 12, 2025" (verified in Node).
5. **Same-slot same-room collisions** — events starting in the same slot split the cell width side by side instead of stacking invisibly.
6. **Day default + URL sync** — defaults to the in-progress conference day (Pacific) when today is Sept 12–14, else Friday (index 0), and the `?day=` param is always written so Friday links survive reload. Composes with the recent `?locations=` param (dbb056b): both are written from state in the same sync effect and parsed together in `page.tsx`.

**META-405 perf item (absorbed):** all `Intl.DateTimeFormat` instances are hoisted to module constants in `utils/dateUtils.ts`, each session's Pacific minutes/duration is computed once in the day-grouping memo, and sessions are bucketed into `Map<locationId, Map<slot, session[]>>` — the render no longer filters the day's events for every slot × location, and the red-line clock label no longer constructs a formatter per tick.

Drive-by: the edit modal's Day select used local-timezone `getDate()`, which yields the previous calendar day for viewers west of Pacific; it now uses Pacific parts.

## Testing required

Preview checks (any account):
- Open `/schedule` and click through all three day tabs — every session in the DB for that day should appear either on the grid or in the "Location TBD" tray. If possible, compare per-day counts against the `sessions` table (sessions with null title/start/end are still excluded by design).
- Confirm the schedule opens on **Friday** by default (today is past the conference), and the URL immediately shows `?day=0`.
- Navigate to each day, reload — the same day should come back. Deep links: `?day=0`, `?day=2&locations=<slug>` should survive reload together, and picking a location filter while on Friday should keep both params in the URL.
- Open a session's detail modal — the date line should read like "Friday, September 12, 2025".
- Hover/click a long session — its block height should match its duration (2px/min) and stay within the day.
- Grid sanity: Saturday/Sunday still start at 09:00 unless an earlier session exists; Friday starts at 14:00 unless there's an earlier session.
- Homepage `#schedule` section still renders and day arrows work (no URL writes there).

### Needs specific DB data (may require seeding a row on preview)
- **Friday-morning session** (e.g. start 2025-09-12 10:00 PT): Friday's grid should extend down to 10:00 and show it. Seed one if none exists.
- **Midnight-crossing session** (e.g. 21:00 → 01:00): renders on its start day from 21:00 to midnight, positive height. Seed one if none exists.
- **Session with `location_id = null`**: appears in the "Location TBD" tray on its day and opens the modal when clicked.
- **Two sessions, same room, same 30-min slot**: both visible side by side at half width.
- **Out-of-range session** (e.g. Oct 13): not rendered, `console.warn` in devtools — confirm it no longer lands on a wrong day.

### Needs a host (non-admin) account
- Edit a session you host that has **no capacities set**, change only the description, Update → should save without the raw Zod `invalid_type` error.
- Set the **category** in the same modal → should persist after refetch (no silent revert).

### Needs an admin account
- Empty-slot click still prefills and creates an event at that slot/room.
- Admin edit path (adminUpdateSession) unaffected — edit an arbitrary session and confirm it saves.

## Noticed but out of scope
- The edit modal can't express a midnight-crossing session (start/end share one day select, and `startTime >= endTime` is rejected), so editing an existing midnight-crosser through the modal would silently truncate it to same-day times. Existing limitation, rendering-only fix here.
- `handleSubmit` hardcodes `year: 2025, month: 9` when building timestamps — fine for this conference, a trap for reuse.
- Prettier isn't runnable in this environment (no node_modules); formatting is hand-matched and there's no format gate in CI, but a `pnpm format` touch-up may reindent the session-block map callback.

Merge-conflict heads-up: this restructures the session block render in `Schedule.tsx` (~old line 515+, now inside `eventsInSlot.map(({ session, startMinutes, durationMinutes }, index) => ...)`) — META-407's keyboard-accessibility change to that same block will conflict with whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PPepDLatLzfSBuBxxsuiU