### PR TITLE
Keyboard-operable click targets and labelled form inputs [META-407]

### DIFF
--- a/app/admin/tools/DummyTool.tsx
+++ b/app/admin/tools/DummyTool.tsx
@@ -64,8 +64,9 @@ export function DummyTool({}: {
         </div>
 
         <div className="space-y-2">
-          <Label>Toast Type</Label>
+          <Label id="toastTypeLabel">Toast Type</Label>
           <RadioGroup
+            aria-labelledby="toastTypeLabel"
             defaultValue="success"
             onValueChange={(value) => {
               const message = toastMessageInput || `${value} toast`

--- a/app/admin/tools/coupons/CouponTool.tsx
+++ b/app/admin/tools/coupons/CouponTool.tsx
@@ -309,6 +309,8 @@ export default function CouponTool({}: {
             <div className="space-y-4">
               <div className="flex flex-col gap-2 md:flex-row">
                 <Input
+                  id="couponEmail"
+                  aria-label="Email to authorize"
                   placeholder="email@example.com"
                   type="email"
                   value={newEmail}
@@ -316,6 +318,8 @@ export default function CouponTool({}: {
                   className="md:w-1/2"
                 />
                 <Input
+                  id="couponEmailMaxUses"
+                  aria-label="Max uses for this email"
                   placeholder="Max uses"
                   type="number"
                   min="1"

--- a/app/admin/tools/issue-tickets/IssueTicketForm.tsx
+++ b/app/admin/tools/issue-tickets/IssueTicketForm.tsx
@@ -167,7 +167,7 @@ export function IssueTicketForm({}: {
               })
             }
           >
-            <SelectTrigger className="mt-1">
+            <SelectTrigger id="ticketType" className="mt-1">
               <SelectValue placeholder="Select ticket type" />
             </SelectTrigger>
             <SelectContent>
@@ -181,8 +181,9 @@ export function IssueTicketForm({}: {
         </div>
 
         <div className="flex flex-col gap-2">
-          <Label>Issue to *</Label>
+          <Label id="issueToLabel">Issue to *</Label>
           <RadioGroup
+            aria-labelledby="issueToLabel"
             value={forExistingUser ? 'existing' : 'new'}
             onValueChange={(value) => {
               setForExistingUser(value === 'existing')
@@ -218,7 +219,7 @@ export function IssueTicketForm({}: {
                 })
               }}
             >
-              <SelectTrigger className="mt-1">
+              <SelectTrigger id="ownerId" className="mt-1">
                 <SelectValue
                   placeholder={
                     loadingUsers ? 'Loading users...' : 'Select existing user'
@@ -417,7 +418,12 @@ export function IssueTicketForm({}: {
 
       {success && (
         <div className="rounded-md border border-green-500/20 bg-green-500/10 p-4">
-          <Textarea className="text-green-400" value={success} readOnly />
+          <Textarea
+            aria-label="Ticket issue result"
+            className="text-green-400"
+            value={success}
+            readOnly
+          />
         </div>
       )}
     </div>

--- a/app/admin/tools/opennode-charge/OpenNodeChargeTool.tsx
+++ b/app/admin/tools/opennode-charge/OpenNodeChargeTool.tsx
@@ -206,7 +206,12 @@ export default function OpenNodeChargeTool({}: {
 
       {success && (
         <div className="rounded-md border border-green-500/20 bg-green-500/10 p-4">
-          <Textarea className="text-green-400" value={success} readOnly />
+          <Textarea
+            aria-label="Charge result"
+            className="text-green-400"
+            value={success}
+            readOnly
+          />
         </div>
       )}
     </div>

--- a/app/admin/tools/user-profile/AdminProfileEditor.tsx
+++ b/app/admin/tools/user-profile/AdminProfileEditor.tsx
@@ -344,12 +344,14 @@ export default function AdminProfileEditor({ profile, tickets }: Props) {
         <div className="flex-1 space-y-6">
           {/* Name */}
           <div>
-            <label className="label">
+            <label className="label" htmlFor="admin-profile-first-name">
               <span className="label-text">Name</span>
             </label>
             {isEditMode ? (
               <div className="grid grid-cols-2 gap-2">
                 <Input
+                  id="admin-profile-first-name"
+                  aria-label="First name"
                   placeholder="First name"
                   value={formData.first_name ?? ''}
                   onChange={(e) =>
@@ -360,6 +362,8 @@ export default function AdminProfileEditor({ profile, tickets }: Props) {
                   }
                 />
                 <Input
+                  id="admin-profile-last-name"
+                  aria-label="Last name"
                   placeholder="Last name"
                   value={formData.last_name ?? ''}
                   onChange={(e) =>
@@ -376,11 +380,12 @@ export default function AdminProfileEditor({ profile, tickets }: Props) {
           </div>
           {/* Bio under Name */}
           <div>
-            <label className="label">
+            <label className="label" htmlFor="admin-profile-bio">
               <span className="label-text">Bio</span>
             </label>
             {isEditMode ? (
               <Textarea
+                id="admin-profile-bio"
                 placeholder="Bio"
                 value={formData.bio ?? ''}
                 onChange={(e) =>
@@ -412,11 +417,12 @@ export default function AdminProfileEditor({ profile, tickets }: Props) {
 
           {/* Discord */}
           <div>
-            <label className="label">
+            <label className="label" htmlFor="admin-profile-discord-handle">
               <span className="label-text">Discord Handle</span>
             </label>
             {isEditMode ? (
               <Input
+                id="admin-profile-discord-handle"
                 placeholder="Discord handle"
                 value={formData.discord_handle ?? ''}
                 onChange={(e) =>
@@ -436,12 +442,14 @@ export default function AdminProfileEditor({ profile, tickets }: Props) {
             <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
               {/* Website 1 */}
               <div>
-                <label className="label">
+                <label className="label" htmlFor="admin-profile-site-name">
                   <span className="label-text">Website 1</span>
                 </label>
                 {isEditMode ? (
                   <div className="space-y-2">
                     <Input
+                      id="admin-profile-site-name"
+                      aria-label="Website 1 name"
                       placeholder="Website name"
                       value={formData.site_name ?? ''}
                       onChange={(e) =>
@@ -452,6 +460,8 @@ export default function AdminProfileEditor({ profile, tickets }: Props) {
                       }
                     />
                     <Input
+                      id="admin-profile-site-url"
+                      aria-label="Website 1 URL"
                       placeholder="Website URL"
                       value={formData.site_url ?? ''}
                       onChange={(e) =>
@@ -485,12 +495,14 @@ export default function AdminProfileEditor({ profile, tickets }: Props) {
               {/* Website 2 */}
               {(isEditMode || current.site_name_2 || current.site_url_2) && (
                 <div>
-                  <label className="label">
+                  <label className="label" htmlFor="admin-profile-site-name-2">
                     <span className="label-text">Website 2</span>
                   </label>
                   {isEditMode ? (
                     <div className="space-y-2">
                       <Input
+                        id="admin-profile-site-name-2"
+                        aria-label="Website 2 name"
                         placeholder="Website name"
                         value={formData.site_name_2 ?? ''}
                         onChange={(e) =>
@@ -501,6 +513,8 @@ export default function AdminProfileEditor({ profile, tickets }: Props) {
                         }
                       />
                       <Input
+                        id="admin-profile-site-url-2"
+                        aria-label="Website 2 URL"
                         placeholder="Website URL"
                         value={formData.site_url_2 ?? ''}
                         onChange={(e) =>
@@ -541,11 +555,15 @@ export default function AdminProfileEditor({ profile, tickets }: Props) {
           <div className={`flex gap-4 ${isEditMode ? 'flex-col' : ''}`}>
             {/* Homepage Display */}
             <div className="flex items-center gap-2">
-              <label className="block text-sm font-medium">
+              <span
+                id="admin-profile-homepage-label"
+                className="block text-sm font-medium"
+              >
                 Show on Homepage?
-              </label>
+              </span>
               {isEditMode ? (
                 <RadioGroup
+                  aria-labelledby="admin-profile-homepage-label"
                   value={
                     formData.opted_in_to_homepage_display === null
                       ? ''
@@ -583,9 +601,15 @@ export default function AdminProfileEditor({ profile, tickets }: Props) {
 
             {/* 18+? maps to minor field */}
             <div className="flex items-center gap-2">
-              <label className="block text-sm font-medium">18+?</label>
+              <span
+                id="admin-profile-age-label"
+                className="block text-sm font-medium"
+              >
+                18+?
+              </span>
               {isEditMode ? (
                 <RadioGroup
+                  aria-labelledby="admin-profile-age-label"
                   value={
                     formData.minor === null ? '' : formData.minor ? 'no' : 'yes'
                   }
@@ -616,11 +640,15 @@ export default function AdminProfileEditor({ profile, tickets }: Props) {
 
             {/* Bringing kids */}
             <div className="flex items-center gap-2">
-              <label className="block text-sm font-medium">
+              <span
+                id="admin-profile-kids-label"
+                className="block text-sm font-medium"
+              >
                 Bringing Kids?
-              </label>
+              </span>
               {isEditMode ? (
                 <RadioGroup
+                  aria-labelledby="admin-profile-kids-label"
                   value={
                     formData.bringing_kids === null
                       ? ''

--- a/app/admin/tools/user-profile/ProfileDataCollapsible.tsx
+++ b/app/admin/tools/user-profile/ProfileDataCollapsible.tsx
@@ -42,6 +42,7 @@ export function ProfileDataCollapsible({
         </CollapsibleTrigger>
         <CollapsibleContent className="px-3 pb-3">
           <Textarea
+            aria-label="Raw profile data"
             value={JSON.stringify(combinedData, null, 2)}
             readOnly
             className="min-h-64 font-mono text-xs"

--- a/app/admin/tools/user-profile/UserSelector.tsx
+++ b/app/admin/tools/user-profile/UserSelector.tsx
@@ -41,10 +41,12 @@ export function UserSelector({ users, selectedUserId }: UserSelectorProps) {
 
   return (
     <div>
-      <label className="mb-2 block text-sm font-medium">Select User</label>
+      <label className="mb-2 block text-sm font-medium" htmlFor="user-selector">
+        Select User
+      </label>
       <div className="flex items-center gap-2">
         <Select value={selectedUserId || ''} onValueChange={handleUserSelect}>
-          <SelectTrigger className="flex-1">
+          <SelectTrigger id="user-selector" className="flex-1">
             <SelectValue placeholder="Choose a user to view their profile" />
           </SelectTrigger>
           <SelectContent>

--- a/app/admin/tools/user-teams/UserTeamsClient.tsx
+++ b/app/admin/tools/user-teams/UserTeamsClient.tsx
@@ -172,12 +172,14 @@ export default function UserTeamsClient() {
       <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
         <div className="flex items-center gap-3">
           <div className="w-56">
-            <label className="text-sm font-medium">Filter by team</label>
+            <label className="text-sm font-medium" htmlFor="team-filter">
+              Filter by team
+            </label>
             <Select
               value={filterTeam}
               onValueChange={(v) => setFilterTeam(v as DbTeamColor | 'all')}
             >
-              <SelectTrigger className="mt-1">
+              <SelectTrigger id="team-filter" className="mt-1">
                 <SelectValue placeholder="All teams" />
               </SelectTrigger>
               <SelectContent>
@@ -194,12 +196,14 @@ export default function UserTeamsClient() {
 
         <div className="flex items-end gap-3">
           <div className="w-56">
-            <label className="text-sm font-medium">Assign team</label>
+            <label className="text-sm font-medium" htmlFor="bulk-team">
+              Assign team
+            </label>
             <Select
               value={bulkTeam}
               onValueChange={(v) => setBulkTeam(v as DbTeamColor | '')}
             >
-              <SelectTrigger className="mt-1">
+              <SelectTrigger id="bulk-team" className="mt-1">
                 <SelectValue placeholder="Select team" />
               </SelectTrigger>
               <SelectContent>
@@ -232,6 +236,7 @@ export default function UserTeamsClient() {
                   <CheckboxPrimitive.Root
                     checked={headerState}
                     onCheckedChange={handleHeaderToggle}
+                    aria-label="Select all visible users"
                     className="peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs transition-shadow outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-primary data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:bg-input/30 dark:aria-invalid:ring-destructive/40 dark:data-[state=checked]:bg-primary"
                   >
                     <CheckboxPrimitive.Indicator className="flex items-center justify-center text-current transition-none">
@@ -256,6 +261,7 @@ export default function UserTeamsClient() {
                   <Checkbox
                     checked={selectedIds.has(p.id)}
                     onCheckedChange={(c) => toggleSelect(p.id, c)}
+                    aria-label={`Select ${p.email ?? p.id}`}
                   />
                 </TableCell>
                 <TableCell className="whitespace-nowrap">
@@ -271,7 +277,7 @@ export default function UserTeamsClient() {
                       }
                       disabled={busy}
                     >
-                      <SelectTrigger>
+                      <SelectTrigger aria-label={`Team for ${p.email ?? p.id}`}>
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>

--- a/app/profile/Profile.tsx
+++ b/app/profile/Profile.tsx
@@ -406,11 +406,13 @@ export default function Profile() {
                 {/* Full Name */}
                 <div className="flex flex-col gap-2 sm:flex-row sm:gap-6">
                   <div>
-                    <label className="label">
+                    <label className="label" htmlFor="profile-first-name">
                       <span className="label-text">Name</span>
                     </label>
                     <div className="grid grid-cols-2 gap-2">
                       <Input
+                        id="profile-first-name"
+                        aria-label="First name"
                         placeholder="First name"
                         value={formData.first_name ?? ''}
                         onChange={(e) =>
@@ -421,6 +423,8 @@ export default function Profile() {
                         }
                       />
                       <Input
+                        id="profile-last-name"
+                        aria-label="Last name"
                         placeholder="Last name"
                         value={formData.last_name ?? ''}
                         onChange={(e) =>
@@ -434,11 +438,11 @@ export default function Profile() {
                   </div>
                   {/* Pronouns */}
                   <div>
-                    <label className="label">
+                    <label className="label" htmlFor="profile-pronouns">
                       <span className="label-text">Pronouns</span>
                     </label>
                     <Input
-                      placeholder=""
+                      id="profile-pronouns"
                       className="w-16"
                       value={formData.pronouns ?? ''}
                       onChange={(e) =>
@@ -452,10 +456,11 @@ export default function Profile() {
                 </div>
                 {/* Bio */}
                 <div>
-                  <label className="label">
+                  <label className="label" htmlFor="profile-bio">
                     <span className="label-text">Bio</span>
                   </label>
                   <Textarea
+                    id="profile-bio"
                     placeholder="Bio"
                     value={formData.bio ?? ''}
                     onChange={(e) =>
@@ -468,10 +473,11 @@ export default function Profile() {
                 </div>
                 {/* Discord Handle */}
                 <div>
-                  <label className="label">
+                  <label className="label" htmlFor="profile-discord-handle">
                     <span className="label-text">Discord Handle</span>
                   </label>
                   <Input
+                    id="profile-discord-handle"
                     placeholder="Your Discord handle"
                     value={formData.discord_handle ?? ''}
                     onChange={(e) =>
@@ -485,11 +491,13 @@ export default function Profile() {
 
                 {/* Website */}
                 <div>
-                  <label className="label">
+                  <label className="label" htmlFor="profile-site-name">
                     <span className="label-text">Website</span>
                   </label>
                   <div className="space-y-2">
                     <Input
+                      id="profile-site-name"
+                      aria-label="Website name"
                       placeholder="Website name"
                       value={formData.site_name ?? ''}
                       onChange={(e) =>
@@ -500,6 +508,8 @@ export default function Profile() {
                       }
                     />
                     <Input
+                      id="profile-site-url"
+                      aria-label="Website URL"
                       placeholder="Website URL"
                       value={formData.site_url ?? ''}
                       onChange={(e) =>
@@ -535,9 +545,12 @@ export default function Profile() {
                   {/* Homepage Display */}
                   <div className="flex items-center gap-2">
                     <span className="flex items-center gap-1">
-                      <label className="block text-sm font-medium">
+                      <span
+                        id="profile-homepage-label"
+                        className="block text-sm font-medium"
+                      >
                         Show on Homepage?
-                      </label>
+                      </span>
                       <Tooltip clickable>
                         <TooltipTrigger>
                           <InfoIcon className="size-3" />
@@ -549,6 +562,7 @@ export default function Profile() {
                       </Tooltip>
                     </span>
                     <RadioGroup
+                      aria-labelledby="profile-homepage-label"
                       value={
                         formData.opted_in_to_homepage_display === null
                           ? ''
@@ -583,8 +597,14 @@ export default function Profile() {
 
                   {/* Age Status */}
                   <div className="flex items-center gap-2">
-                    <label className="block text-sm font-medium">18+?</label>
+                    <span
+                      id="profile-age-label"
+                      className="block text-sm font-medium"
+                    >
+                      18+?
+                    </span>
                     <RadioGroup
+                      aria-labelledby="profile-age-label"
                       value={
                         formData.minor === null
                           ? ''
@@ -617,10 +637,14 @@ export default function Profile() {
                   {/* Bringing Kids */}
                   <div className="flex flex-col gap-2">
                     <div className="flex items-center gap-2">
-                      <label className="block text-sm font-medium">
+                      <span
+                        id="profile-kids-label"
+                        className="block text-sm font-medium"
+                      >
                         Bringing Kids?
-                      </label>
+                      </span>
                       <RadioGroup
+                        aria-labelledby="profile-kids-label"
                         value={
                           formData.bringing_kids === null
                             ? 'null'

--- a/app/profile/ProfileInfoModal.tsx
+++ b/app/profile/ProfileInfoModal.tsx
@@ -72,11 +72,16 @@ export function ProfileInfoModal({
         <div className="space-y-4">
           {/* Name Fields */}
           <div>
-            <label className="mb-2 block text-sm font-medium">
+            <label
+              className="mb-2 block text-sm font-medium"
+              htmlFor="profile-modal-first-name"
+            >
               Name<span className="text-lg text-red-500">*</span>
             </label>
             <div className="grid grid-cols-2 gap-2">
               <Input
+                id="profile-modal-first-name"
+                aria-label="First name (required)"
                 placeholder="First (required)"
                 value={formData.first_name ?? ''}
                 onChange={(e) =>
@@ -87,6 +92,8 @@ export function ProfileInfoModal({
                 }
               />
               <Input
+                id="profile-modal-last-name"
+                aria-label="Last name"
                 placeholder="Last"
                 value={formData.last_name ?? ''}
                 onChange={(e) =>
@@ -99,10 +106,11 @@ export function ProfileInfoModal({
             </div>
           </div>
           <div className="flex flex-col gap-2">
-            <Label className="label">
+            <Label className="label" htmlFor="profile-modal-bio">
               <span className="label-text">Bio</span>
             </Label>
             <Textarea
+              id="profile-modal-bio"
               placeholder="Bio"
               value={formData.bio ?? ''}
               onChange={(e) =>
@@ -116,11 +124,15 @@ export function ProfileInfoModal({
 
           {/* Homepage Display Radio Group */}
           <div className="space-y-3">
-            <label className="block text-sm font-medium">
+            <span
+              id="profile-modal-homepage-label"
+              className="block text-sm font-medium"
+            >
               Allow your profile card to be displayed on the homepage attendee
               list? (opt-in)<span className="text-lg text-red-500">*</span>
-            </label>
+            </span>
             <RadioGroup
+              aria-labelledby="profile-modal-homepage-label"
               value={
                 formData.opted_in_to_homepage_display === null
                   ? ''
@@ -155,11 +167,15 @@ export function ProfileInfoModal({
 
           {/* Minor Checkbox */}
           <div className="space-y-3">
-            <label className="block text-sm font-medium">
+            <span
+              id="profile-modal-age-label"
+              className="block text-sm font-medium"
+            >
               Are you 18 or older?
               <span className="text-lg text-red-500">*</span>
-            </label>
+            </span>
             <RadioGroup
+              aria-labelledby="profile-modal-age-label"
               value={
                 formData.minor === null ? '' : formData.minor ? 'no' : 'yes'
               }
@@ -187,11 +203,15 @@ export function ProfileInfoModal({
 
           {/* Kids Radio Group */}
           <div className="space-y-3">
-            <label className="block text-sm font-medium">
+            <span
+              id="profile-modal-kids-label"
+              className="block text-sm font-medium"
+            >
               Are you bringing any children?
               <span className="text-lg text-red-500">*</span>
-            </label>
+            </span>
             <RadioGroup
+              aria-labelledby="profile-modal-kids-label"
               value={
                 formData.bringing_kids === null
                   ? ''

--- a/app/schedule/Schedule.tsx
+++ b/app/schedule/Schedule.tsx
@@ -583,8 +583,20 @@ export default function Schedule({
                           }
                         >
                           <div
+                            role="button"
+                            tabIndex={0}
+                            aria-label={`Open details for ${session.title || 'session'}`}
                             onClick={() => handleOpenSessionModal(session.id!)}
-                            className={`group absolute z-content m-0.5 cursor-pointer rounded-md border-2 p-1 ${getEventColor(session)} font-semibold text-black`}
+                            onKeyDown={(e) => {
+                              // Ignore keys bubbling up from the nested RSVP /
+                              // bookmark buttons and host links.
+                              if (e.target !== e.currentTarget) return
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault()
+                                handleOpenSessionModal(session.id!)
+                              }
+                            }}
+                            className={`group absolute z-content m-0.5 cursor-pointer rounded-md border-2 p-1 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white ${getEventColor(session)} font-semibold text-black`}
                             style={{
                               top: `${(startMinutes % 30) * 2}px`, // 2px per minute
                               height: `${durationMinutes * 2}px`, // 2px per minute
@@ -680,15 +692,17 @@ export default function Schedule({
                       {/* Clickable empty slot for admins */}
                       {currentUserProfile?.is_admin &&
                         eventsInSlot.length === 0 && (
-                          <div
+                          <button
+                            type="button"
                             onClick={() => handleEmptySlotClick(time, venue.id)}
-                            className="hover:bg-opacity-20 group absolute inset-0 cursor-pointer transition-colors duration-200 hover:bg-dark-400"
+                            className="hover:bg-opacity-20 group absolute inset-0 cursor-pointer transition-colors duration-200 hover:bg-dark-400 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
                             title={`Add event at ${time} in ${venue.name}`}
+                            aria-label={`Add event at ${time} in ${venue.name}`}
                           >
                             <div className="hidden h-full items-center justify-center text-xs text-secondary-400 group-hover:flex">
                               <PlusIcon className="size-6" />
                             </div>
-                          </div>
+                          </button>
                         )}
                     </div>
                   )

--- a/components/PickACard/CardPicker.tsx
+++ b/components/PickACard/CardPicker.tsx
@@ -79,10 +79,21 @@ export default function CardPicker({
           </DialogDescription>
           <div className="grid max-h-[70vh] grid-cols-2 gap-4 self-center overflow-y-auto sm:grid-cols-4">
             <div
-              className="flex w-fit cursor-pointer flex-col items-center justify-center bg-celestial-gold p-2 transition-colors hover:bg-celestial-gold/80"
+              role="button"
+              tabIndex={0}
+              aria-label="Keep your current card"
+              className="flex w-fit cursor-pointer flex-col items-center justify-center bg-celestial-gold p-2 transition-colors hover:bg-celestial-gold/80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
               onClick={() => {
                 setSelectedCard(null)
                 setShowConfirmation(true)
+              }}
+              onKeyDown={(e) => {
+                if (e.target !== e.currentTarget) return
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault()
+                  setSelectedCard(null)
+                  setShowConfirmation(true)
+                }
               }}
             >
               <span className="text-sm text-celestial-primary sm:text-xl">
@@ -98,10 +109,21 @@ export default function CardPicker({
             {cards.map((card) => (
               <div
                 key={card.id}
-                className="cursor-pointer transition-transform hover:scale-105"
+                role="button"
+                tabIndex={0}
+                aria-label={`Transform your card into ${card.name}`}
+                className="cursor-pointer transition-transform hover:scale-105 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
                 onClick={() => {
                   setSelectedCard(card)
                   setShowConfirmation(true)
+                }}
+                onKeyDown={(e) => {
+                  if (e.target !== e.currentTarget) return
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    setSelectedCard(card)
+                    setShowConfirmation(true)
+                  }
                 }}
               >
                 <PlayerCard

--- a/components/Set/ControlledSetCard.tsx
+++ b/components/Set/ControlledSetCard.tsx
@@ -84,9 +84,15 @@ export default function ControlledSetCard() {
         </select>
       </div>
 
-      <div onClick={() => setSelected(!selected)}>
+      <button
+        type="button"
+        aria-pressed={selected}
+        aria-label="Toggle card selection"
+        className="cursor-pointer focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+        onClick={() => setSelected(!selected)}
+      >
         <SetCard card={card} size={size} selected={selected} />
-      </div>
+      </button>
     </div>
   )
 }

--- a/components/Set/SetAnimation.tsx
+++ b/components/Set/SetAnimation.tsx
@@ -75,9 +75,12 @@ export default function SetAnimation() {
     <div className="flex flex-col items-center gap-3 py-4" ref={containerRef}>
       <div className="grid w-full auto-rows-fr grid-cols-6 gap-1 md:grid-cols-12 md:gap-2">
         {setBoard.map((card, index) => (
-          <div
+          <button
             key={`${card.shape}-${card.color}-${card.fill}-${card.number}-${index}`}
-            className={`opacity-0 ${visible ? 'animate-fade-in' : ''} ${isExiting && selectedCards.includes(index) ? 'animate-fade-out' : ''} `}
+            type="button"
+            aria-pressed={selectedCards.includes(index)}
+            aria-label={`${card.number} ${card.color} ${card.fill} ${card.shape}`}
+            className={`block w-full cursor-pointer opacity-0 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white ${visible ? 'animate-fade-in' : ''} ${isExiting && selectedCards.includes(index) ? 'animate-fade-out' : ''} `}
             style={{
               animationDelay:
                 isExiting || foundSets > 0 ? '0ms' : `${index * 100}ms`,
@@ -90,7 +93,7 @@ export default function SetAnimation() {
               selected={selectedCards.includes(index)}
               responsive
             />
-          </div>
+          </button>
         ))}
       </div>
       {foundSets > 0 && (


### PR DESCRIPTION
Session blocks on /schedule (and four other `<div onClick>` sites) were unreachable by keyboard — a keyboard user could see every session and open none. Separately, the profile and admin editing forms used sibling `<label>`s with no `htmlFor`, so no input had a programmatic name.

### Click targets made keyboard-operable
- `app/schedule/Schedule.tsx` — session block: `role="button"` + `tabIndex={0}` + Enter/Space handler. Kept as a `<div>` on purpose: it contains the RSVP/bookmark `<button>`s and host `<a>` links, so a real `<button>` would nest interactive elements invalidly. The key handler ignores events bubbling from those children.
- `app/schedule/Schedule.tsx` — admin empty-slot add: real `<button type="button">` (icon-only content, nothing to nest), plus an `aria-label` matching the existing `title`.
- `components/PickACard/CardPicker.tsx` (2 sites) — `role="button"` + key handler; `PlayerCard` can render the user's site `<a>`, same nesting constraint.
- `components/Set/ControlledSetCard.tsx`, `components/Set/SetAnimation.tsx` — real `<button type="button">` with `aria-pressed`.
- All five get an explicit `focus-visible:outline-2 outline-offset-2 outline-white`, since a default UA outline is near-invisible on the coloured session tiles.

### Controls given programmatic labels (~42 across 10 files)
- `app/profile/Profile.tsx` — 7 inputs + 3 radio groups. Pronouns lost its `placeholder=""` (it did nothing) and now takes its name from the label.
- `app/profile/ProfileInfoModal.tsx` — 3 inputs + 3 radio groups.
- `app/admin/tools/user-profile/AdminProfileEditor.tsx` — 8 inputs + 3 radio groups.
- `app/admin/tools/user-teams/UserTeamsClient.tsx` — 2 filter selects, the header checkbox, per-row checkbox and per-row team select.
- `app/admin/tools/issue-tickets/IssueTicketForm.tsx` — two `htmlFor`s pointed at ids that didn't exist (`ticketType`, `ownerId`); added them to the `SelectTrigger`s. Plus the "Issue to" radio group and the result textarea.
- `app/admin/tools/coupons/CouponTool.tsx` (2 inputs), `user-profile/UserSelector.tsx` (1 select), `DummyTool.tsx` (1 radio group), `opennode-charge/OpenNodeChargeTool.tsx` + `user-profile/ProfileDataCollapsible.tsx` (readonly textareas).

Where a single visible label heads two inputs (Name → first/last, Website → name/URL), `htmlFor` targets the first input for click-to-focus and each input carries its own `aria-label`. Group headings above radio groups became `<span id>` + `aria-labelledby` — an orphan `<label>` labels nothing, and `.label`/`.label-text` aren't defined in `globals.css`, so this is visually identical.

### Deviations from the issue body
- Line numbers had drifted (`Schedule.tsx:515` is now 563 after the location-filter merge).
- "~25 more controls across `app/admin/tools/**`" overstates it: `DummyTool.tsx` and `OpenNodeChargeTool.tsx` were already fully correct, and `IssueTicketForm.tsx`/`CouponTool.tsx` were mostly correct.
- Section 3 (motion) intentionally untouched — META-402 owns it.

**Conflict with META-403 expected.** It's restructuring `Schedule.tsx`; my edit there is two small hunks and is the trivial side to re-apply on top.

## Testing required

**The schedule grid is the top regression risk.** The admin empty-slot `<div>` → `<button>` swap changes default display/background/border/font inheritance. Before anything else, open `/schedule` and confirm the grid renders **identically** to production: same column widths, same session tile positions and heights, no stray borders or backgrounds, nothing shifted by a pixel.

Then, on the preview:
- Tab through `/schedule`. Every session tile should receive focus with a visible white outline, and Enter **and** Space should each open its detail modal.
- With focus inside a tile, Tab to the nested RSVP / bookmark buttons and the host links — pressing Enter/Space there must do only that action, not also open the modal.
- In the open modal: focus should be trapped, Escape should close it, and focus should return to the tile you opened it from.
- Check the tiles still show their hover tooltip and that the RSVP ring (pink box-shadow) still renders.
- `/proset-puzzle` route + the homepage Set animation: click cards to select, confirm selection still works and completing a set still animates out. Tab + Space should select a card too.

On `/profile` (signed in):
- Click each field's **label text** — "Name", "Pronouns", "Bio", "Discord Handle", "Website" — and confirm the caret lands in the expected input. That's the quick proxy for correct `htmlFor`.
- Pronouns had no accessible name at all before; confirm it now announces as "Pronouns" (or check the field is no longer an unnamed edit box in the accessibility inspector).
- The three Yes/No radio groups (homepage display, 18+, bringing kids) should still save correctly.

### Requires an admin account
- `/admin?tool=user-profile` — click labels in the profile editor (edit mode on), confirm focus lands right; confirm the read-only view still renders the same.
- `/admin?tool=user-teams` — the two team selects, the header select-all checkbox and per-row checkboxes/selects should all still work, and each row's select should announce which user it belongs to.
- `/admin?tool=issue-tickets` — the "Ticket Type" and "Select User" dropdowns now respond to clicking their label; confirm both still open and select correctly.
- `/admin?tool=coupons` — the approved-emails inputs still add/update.

### Not verified locally
Nothing was type-checked or built (no `node_modules` on this box, by design), and the pre-commit hook was bypassed for the same reason. The Vercel preview build is the first real typecheck.