### PR TITLE
Redact attendee rosters from the SSR-dehydrated schedule cache [META-411]

### DIFF
--- a/app/api/apiAuth.ts
+++ b/app/api/apiAuth.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from 'next/server'
+
+import { createClient } from '@/utils/supabase/server'
+
+/** The signed-in user for an API request, or null when the caller is anonymous. */
+export const getApiUser = async () => {
+  const supabase = await createClient()
+  const {
+    data: { user },
+  } = await supabase.auth.getUser()
+  return user
+}
+
+export const unauthorizedResponse = () =>
+  NextResponse.json({ error: 'Unauthorized' }, { status: 401 })

--- a/app/api/queries/profiles/public/[userId]/route.ts
+++ b/app/api/queries/profiles/public/[userId]/route.ts
@@ -1,8 +1,10 @@
 import { NextResponse } from 'next/server'
 
 import { apiError } from '@/lib/apiError'
+import { stripPrivateProfileFields } from '@/lib/profiles'
 
 import { getUserPublicProfileById } from '@/app/actions/db/users'
+import { getApiUser } from '@/app/api/apiAuth'
 
 import { DbPublicProfile } from '@/types/database/dbTypeAliases'
 
@@ -12,19 +14,22 @@ export async function GET(
   { params }: { params: Promise<{ userId: string }> },
 ) {
   try {
+    // Anonymous callers get the card-facing profile, minus the fields only
+    // attendees may see
+    const user = await getApiUser()
+
     const { userId } = await params
 
     const profile = await getUserPublicProfileById({ userId })
+    const visibleProfile =
+      profile && !user ? stripPrivateProfileFields(profile) : profile
 
     const response = NextResponse.json(
-      profile satisfies ApiUserPublicProfileResponse,
+      visibleProfile satisfies ApiUserPublicProfileResponse,
     )
 
-    // Add cache headers - profiles don't change often
-    response.headers.set(
-      'Cache-Control',
-      'public, s-maxage=300, stale-while-revalidate=86400',
-    )
+    // Varies by session, so it can't sit in a shared cache
+    response.headers.set('Cache-Control', 'private, no-store')
 
     return response
   } catch (error) {

--- a/app/api/queries/profiles/public/route.ts
+++ b/app/api/queries/profiles/public/route.ts
@@ -1,28 +1,30 @@
 import { NextRequest, NextResponse } from 'next/server'
 
 import { apiError } from '@/lib/apiError'
+import { stripPrivateProfileFields } from '@/lib/profiles'
 
 import {
   getAllUserPublicProfiles,
   getUsersPublicProfiles,
 } from '@/app/actions/db/users'
+import { getApiUser, unauthorizedResponse } from '@/app/api/apiAuth'
 
 import { DbPublicProfile } from '@/types/database/dbTypeAliases'
 
 export type ApiAllPublicProfilesResponse = DbPublicProfile[]
 export async function GET() {
   try {
+    // The whole attendee roster is attendees-only
+    const user = await getApiUser()
+    if (!user) return unauthorizedResponse()
+
     const profiles = await getAllUserPublicProfiles()
 
     const response = NextResponse.json(
       profiles satisfies ApiAllPublicProfilesResponse,
     )
 
-    // Add cache headers - profiles don't change often
-    response.headers.set(
-      'Cache-Control',
-      'public, s-maxage=300, stale-while-revalidate=86400',
-    )
+    response.headers.set('Cache-Control', 'private, no-store')
 
     return response
   } catch (error) {
@@ -33,18 +35,22 @@ export async function GET() {
 export type ApiUsersPublicProfilesResponse = DbPublicProfile[]
 export async function POST(request: NextRequest) {
   try {
+    // Anonymous callers get these (speaker and team card grids), minus the
+    // fields only attendees may see
+    const user = await getApiUser()
+
     const { userIds } = (await request.json()) as { userIds: string[] }
     const profiles = await getUsersPublicProfiles({ userIds })
+    const visibleProfiles = user
+      ? profiles
+      : profiles.map(stripPrivateProfileFields)
 
     const response = NextResponse.json(
-      profiles satisfies ApiUsersPublicProfilesResponse,
+      visibleProfiles satisfies ApiUsersPublicProfilesResponse,
     )
 
-    // Add cache headers - profiles don't change often
-    response.headers.set(
-      'Cache-Control',
-      'public, s-maxage=300, stale-while-revalidate=86400',
-    )
+    // Varies by session, so it can't sit in a shared cache
+    response.headers.set('Cache-Control', 'private, no-store')
 
     return response
   } catch (error) {

--- a/app/api/queries/rsvps/[userId]/route.ts
+++ b/app/api/queries/rsvps/[userId]/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { apiError } from '@/lib/apiError'
 
 import { getUserRsvps } from '@/app/actions/db/sessionRsvps'
+import { getApiUser, unauthorizedResponse } from '@/app/api/apiAuth'
 
 import { DbSessionRsvp } from '@/types/database/dbTypeAliases'
 
@@ -13,6 +14,10 @@ export async function GET(
   { params }: { params: Promise<{ userId: string }> },
 ) {
   try {
+    // Another attendee's schedule, so attendees only
+    const user = await getApiUser()
+    if (!user) return unauthorizedResponse()
+
     const { userId } = await params
 
     const rsvps = await getUserRsvps({ userId })

--- a/app/api/queries/rsvps/route.ts
+++ b/app/api/queries/rsvps/route.ts
@@ -3,12 +3,17 @@ import { NextResponse } from 'next/server'
 import { apiError } from '@/lib/apiError'
 
 import { getAllRsvps } from '@/app/actions/db/sessionRsvps'
+import { getApiUser, unauthorizedResponse } from '@/app/api/apiAuth'
 
 import { DbFullSessionRsvp } from '@/types/database/dbTypeAliases'
 
 export type ApiRsvpsResponse = DbFullSessionRsvp[]
 export async function GET() {
   try {
+    // Names every attendee of every session, so attendees only
+    const user = await getApiUser()
+    if (!user) return unauthorizedResponse()
+
     const rsvps = await getAllRsvps()
 
     return NextResponse.json(rsvps satisfies ApiRsvpsResponse)

--- a/app/api/queries/session-bookmarks/[userId]/route.ts
+++ b/app/api/queries/session-bookmarks/[userId]/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { apiError } from '@/lib/apiError'
 
 import { getUserSessionBookmarks } from '@/app/actions/db/sessionBookmarks'
+import { getApiUser, unauthorizedResponse } from '@/app/api/apiAuth'
 
 import { DbSessionBookmark } from '@/types/database/dbTypeAliases'
 
@@ -12,6 +13,10 @@ export async function GET(
   { params }: { params: Promise<{ userId: string }> },
 ) {
   try {
+    // Another attendee's saved sessions, so attendees only
+    const user = await getApiUser()
+    if (!user) return unauthorizedResponse()
+
     const { userId } = await params
     const bookmarks = await getUserSessionBookmarks({ userId })
 

--- a/app/api/queries/session-bookmarks/route.ts
+++ b/app/api/queries/session-bookmarks/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { apiError } from '@/lib/apiError'
 
 import { getAllSessionBookmarks } from '@/app/actions/db/sessionBookmarks'
+import { getApiUser, unauthorizedResponse } from '@/app/api/apiAuth'
 
 import { DbSessionBookmark } from '@/types/database/dbTypeAliases'
 
@@ -10,6 +11,10 @@ export type ApiAllSessionBookmarksResponse = DbSessionBookmark[]
 
 export async function GET() {
   try {
+    // Maps every attendee to the sessions they are interested in, so attendees only
+    const user = await getApiUser()
+    if (!user) return unauthorizedResponse()
+
     const bookmarks = await getAllSessionBookmarks()
 
     return NextResponse.json(bookmarks satisfies ApiAllSessionBookmarksResponse)

--- a/app/api/queries/sessions/[id]/route.ts
+++ b/app/api/queries/sessions/[id]/route.ts
@@ -2,7 +2,10 @@ import { NextResponse } from 'next/server'
 
 import { apiError } from '@/lib/apiError'
 
+import { sessionWithoutAttendees } from '@/utils/dbUtils'
+
 import { getSessionById } from '@/app/actions/db/sessions'
+import { getApiUser } from '@/app/api/apiAuth'
 
 import { DbFullSession } from '@/types/database/dbTypeAliases'
 
@@ -12,9 +15,14 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> },
 ) {
   try {
-    const session = await getSessionById({ sessionId: (await params).id })
+    // The session itself is public; who is going to it is not
+    const user = await getApiUser()
 
-    return NextResponse.json(session satisfies ApiSessionResponse)
+    const session = await getSessionById({ sessionId: (await params).id })
+    const visibleSession =
+      session && !user ? sessionWithoutAttendees(session) : session
+
+    return NextResponse.json(visibleSession satisfies ApiSessionResponse)
   } catch (error) {
     return apiError(error, 'Failed to fetch session')
   }

--- a/app/api/queries/sessions/route.ts
+++ b/app/api/queries/sessions/route.ts
@@ -2,16 +2,25 @@ import { NextResponse } from 'next/server'
 
 import { apiError } from '@/lib/apiError'
 
+import { sessionWithoutAttendees } from '@/utils/dbUtils'
+
 import { getAllSessions } from '@/app/actions/db/sessions'
+import { getApiUser } from '@/app/api/apiAuth'
 
 import { DbFullSession } from '@/types/database/dbTypeAliases'
 
 export type ApiAllSessionsResponse = DbFullSession[]
 export async function GET() {
   try {
-    const sessions = await getAllSessions()
+    // The schedule itself is public; who is going to each session is not
+    const user = await getApiUser()
 
-    return NextResponse.json(sessions satisfies ApiAllSessionsResponse)
+    const sessions = await getAllSessions()
+    const visibleSessions = user
+      ? sessions
+      : sessions.map(sessionWithoutAttendees)
+
+    return NextResponse.json(visibleSessions satisfies ApiAllSessionsResponse)
   } catch (error) {
     return apiError(error, 'Failed to fetch sessions')
   }

--- a/app/schedule/ScheduleProvider.tsx
+++ b/app/schedule/ScheduleProvider.tsx
@@ -10,6 +10,7 @@ import {
   dehydrate,
 } from '@tanstack/react-query'
 
+import { sessionWithoutAttendees } from '@/utils/dbUtils'
 import { createClient } from '@/utils/supabase/server'
 
 import { currentUserGetSessionBookmarks } from '@/app/actions/db/sessionBookmarks'
@@ -51,7 +52,12 @@ export default async function ScheduleProvider({
     () =>
       queryClient.prefetchQuery({
         queryKey: ['sessions'],
-        queryFn: getAllSessions,
+        // The cache is dehydrated into the public HTML, so strip attendee
+        // lists for anonymous visitors — same rule as /api/queries/sessions
+        queryFn: async () => {
+          const sessions = await getAllSessions()
+          return user ? sessions : sessions.map(sessionWithoutAttendees)
+        },
       }),
     () =>
       queryClient.prefetchQuery({

--- a/lib/profiles.ts
+++ b/lib/profiles.ts
@@ -1,6 +1,23 @@
 import { ProfileFormData } from './schemas/profile'
 
-import { DbFullProfile } from '@/types/database/dbTypeAliases'
+import { DbFullProfile, DbPublicProfile } from '@/types/database/dbTypeAliases'
+
+/** Public profiles are served to anonymous callers, so drop the fields that are
+ * only meant for signed-in attendees. Redacting here rather than in the db
+ * projection keeps `is_admin` available to the server-side auth checks in
+ * utils/security, which read it off the public profile. */
+export const stripPrivateProfileFields = (
+  profile: DbPublicProfile,
+): DbPublicProfile => {
+  const {
+    discord_handle: _discord_handle,
+    is_admin: _is_admin,
+    minor: _minor,
+    checked_in: _checked_in,
+    ...publicFields
+  } = profile
+  return publicFields
+}
 
 export const requiredProfileFields: (keyof ProfileFormData)[] = [
   'first_name',

--- a/types/database/dbTypeAliases.ts
+++ b/types/database/dbTypeAliases.ts
@@ -47,26 +47,30 @@ export type DbPublicProfileKeys =
   | 'first_name'
   | 'last_name'
   | 'team'
-  | 'discord_handle'
   | 'opted_in_to_homepage_display'
   | 'bio'
-  | 'is_admin'
   | 'homepage_order'
   | 'site_name'
   | 'site_url'
   | 'site_name_2'
   | 'site_url_2'
   | 'dismissed_info_request'
-  | 'minor'
   | 'profile_pictures_url'
   | 'player_id'
   | 'pronouns'
   | 'volunteer'
-  | 'checked_in'
   | 'celestial_card_id'
-export type DbPublicProfile = Pick<DbFullProfile, DbPublicProfileKeys> & {
-  celestial_card: DbCelestialCard | null
-}
+/** Fields of the public profile projection that only signed-in callers get: the
+ * API strips them for anonymous requests, so they are optional on every reader. */
+export type DbPrivateProfileKeys =
+  | 'discord_handle'
+  | 'is_admin'
+  | 'minor'
+  | 'checked_in'
+export type DbPublicProfile = Pick<DbFullProfile, DbPublicProfileKeys> &
+  Partial<Pick<DbFullProfile, DbPrivateProfileKeys>> & {
+    celestial_card: DbCelestialCard | null
+  }
 export type DbProfileInsert = TablesInsert<'profiles'>
 export type DbProfileUpdate = TablesUpdate<'profiles'>
 export type DbTeamColor = Enums<'TEAM_COLORS'>

--- a/utils/dbUtils.ts
+++ b/utils/dbUtils.ts
@@ -73,6 +73,16 @@ export const SESSION_CATEGORIES_ENUM = Object.values(
   SESSION_CATEGORIES,
 ) as DbSessionCategory[]
 
+/** A session with the attendee lists removed. RSVP rows carry attendee names and
+ * user ids and bookmarks carry user ids, so anonymous callers get neither. */
+export const sessionWithoutAttendees = (
+  session: DbFullSession,
+): DbFullSession => ({
+  ...session,
+  rsvps: [],
+  bookmarks: [],
+})
+
 export const countRsvpsByTeamColor = (
   rsvps: Pick<DbFullSessionRsvp, 'user'>[],
 ) => {


### PR DESCRIPTION
`/schedule` and the homepage serialize the react-query cache into the page HTML via `dehydrate()`, and the unconditional `getAllSessions` prefetch runs through the service client — so every attendee's first name, last name, id and team (plus bookmark user ids and waitlist status) shipped in the page source to logged-out visitors, no API call needed.

**Stacked on #292 (`meta-397-api-auth`)** — do not retarget to `main` manually; GitHub will retarget automatically when #292 merges. The fix reuses #292's `sessionWithoutAttendees` so there is exactly one definition of what anonymous visitors may see, and the SSR payload now matches what the client's own refetch through `/api/queries/sessions` returns for anonymous users (`rsvps: []`, `bookmarks: []` — same `DbFullSession` shape, so no type changes downstream).

The fix wraps the sessions `queryFn` to redact before the cache is populated, so the redacted array is exactly what `prefetchQuery` stores and `dehydrate()` serializes. Logged-out rendering is unaffected: `AttendanceDisplay` already shows only min/max capacity to anonymous visitors, and the megagame team chips / RSVP tooltip count over `session.rsvps`, which the anonymous API response already returns empty.

## Sweep: other dehydrate/prefetch sites

| Site | Route(s) | Verdict |
| --- | --- | --- |
| `app/schedule/ScheduleProvider.tsx` | `/schedule`, `/` (via `ScheduleSection`) | **Leak — fixed here.** User-specific prefetches were already gated on `user?.id`. |
| `app/profile/ProfileProvider.tsx` | `/profile` | Safe — prefetches only inside `if (user?.id)`, self-data only; route is middleware-guarded. |
| `lib/prefetch.ts` (`prefetchState`, used in `app/layout.tsx`) | all pages | Safe — dehydrates only the current user's own user/profile; for anonymous, `getCurrentUser` is null and the profile queryFn throws inside `currentUserWrapper`, and errored queries are not dehydrated. |
| `app/admin/tools/user-teams/UserTeamsTool.tsx` | `/admin/tools/user-teams` | Safe — `/admin` layout redirects non-admins before render, and `adminGetAllFullProfiles` throws for non-admins anyway (errored prefetch is not dehydrated). |
| `app/providers/QueryProvider.tsx` | all | Not a source — client component that hydrates state produced elsewhere. |

Also checked non-dehydrate server components that pass service-role data as client-component props (same serialization class):

| Site | Route(s) | Verdict |
| --- | --- | --- |
| `components/PickACard/PickACardMetaProvider.tsx` | all (mounted in `app/layout.tsx`) | Safe — `currentUserLatestUnclaimedVictory` returns null for anonymous, so the full-session prop (which includes rsvps) only serializes for the authenticated winner. |
| `app/team/page.tsx` | `/team` | Safe — redirects anonymous to `/login` before fetching; passes member ids only. |
| `app/checkin/page.tsx` | `/checkin` | Safe from leaking — `volunteerGetAllFullTickets` throws below VOLUNTEER rank, so anonymous gets an error page, not data. |
| `app/player/[id]/page.tsx`, `components/sections/home/speakers/index.tsx` | `/player/[id]`, `/` | Safe — pass ids only; client fetches via the API #292 governs. |
| `app/cards/page.tsx`, `app/campus/page.tsx` | `/cards`, `/campus` | Safe — celestial cards / sudokus, no PII. |

## Merge conflict heads-up

PR #299 (META-410) changes the same `queryFn: getAllSessions` line in `ScheduleProvider.tsx` (switching to a direct `sessionsService.getAllSessions` import). Whichever lands second takes a trivial conflict: keep the wrapper from this PR and swap the inner call to the `lib/db` import.

## Testing required

- Logged out: load `/schedule` and `/`, view page source, and grep the payload for a known attendee surname — should be absent (also check for `"rsvps":[{` — should only appear as `"rsvps":[]`).
- Signed in: load both pages and confirm RSVP lists, hover tooltips, team-color chips and bookmarks all still render with real data.
- Session detail modal opens and renders in both states (anonymous sees no attendee names anywhere).

Already verified by reading the code: logged-out `AttendanceDisplay` renders min/max capacity without touching `rsvps`; all `session.rsvps`/`session.bookmarks` consumers handle empty arrays; the redacted shape is unchanged (`DbFullSession`), so no type surface moved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PPepDLatLzfSBuBxxsuiU