### PR TITLE
Add a CI job that typechecks, lints, and builds [META-421]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  checks:
+    name: typecheck / lint / build
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY }}
+          SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
+          # lib/opennode.ts and lib/email.ts construct clients at module scope, so
+          # the build fails without these even though nothing calls out during it.
+          # Placeholders, not real credentials — drop them once those two modules
+          # initialize lazily.
+          OPENNODE_KEY: ci-placeholder
+          RESEND_API_KEY: ci-placeholder

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -18,10 +18,10 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 9
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Cache Playwright browsers
         uses: actions/cache@v4


### PR DESCRIPTION
CI has never run `tsc`, `next lint`, or a production build — the only PR workflow ran Playwright, which starts the app with `pnpm dev` and compiles lazily, so type errors never surfaced. This adds a `checks` job that runs all three.

- Both workflows move to pnpm 9 (the lockfile is `lockfileVersion: 9.0`; CI pinned 8, so it may not have been resolving the tree the lockfile describes) and use `--frozen-lockfile`
- The build step needs `OPENNODE_KEY` and `RESEND_API_KEY` placeholders because `lib/opennode.ts:8` throws and `lib/email.ts:9` constructs a Resend client, both at module scope. Nothing calls out during a build — making those lazy is a follow-up in META-433, after which the placeholders can go

## Expect this to be red

Nobody has ever run these checks against this tree, including the sixteen agent-written PRs merged last week. Pre-existing type or lint errors are likely, and finding them is the point. **Read the failures before merging** — if they're real, they're the most valuable output of this PR.

## Testing required

Nothing manual. The PR's own run is the test: check whether `typecheck / lint / build` passes and triage anything it surfaces.

## Follow-up, not in this PR

The `main` ruleset (`6860964`) has no `required_status_checks` rule and `required_approving_review_count: 0`, so a red PR can still be merged. Once this job is green, add it as a required check — that's the half that actually gates anything, and it needs repo admin.