### PR TITLE
Compare-and-swap the waitlist promotion and sudoku first-solve races [META-427]

### DIFF
--- a/lib/db/sessionRsvps.ts
+++ b/lib/db/sessionRsvps.ts
@@ -4,6 +4,11 @@ import { createServiceClient } from '@/utils/supabase/service'
 
 import { DbFullSessionRsvp, DbTeamColor } from '@/types/database/dbTypeAliases'
 
+// Extra promotion passes allowed beyond `limit` when rows keep getting claimed
+// out from under us. Bounds the retry loop so it can never spin on a session
+// that is being continuously re-waitlisted.
+const MAX_LOST_PASSES = 5
+
 const sessionRsvpsSelectIncludes = `
         *,
         user:profiles!session_rsvps_user_id_fkey (
@@ -78,7 +83,13 @@ export const sessionRsvpsService = {
   },
   /**
    * Pop earliest waitlisted users, optionally filtered by team, up to `limit`.
-   * Returns array of userIds popped. No-op (empty array) if none.
+   * Returns array of userIds actually popped. No-op (empty array) if none.
+   *
+   * The promotion is a compare-and-swap rather than a blind write: only rows
+   * that are still `on_waitlist` are claimed, and the rows PostgREST returns
+   * are exactly the ones this caller won. Losing a row to a concurrent
+   * promoter therefore re-reads the waitlist and tries the next person instead
+   * of silently stranding the freed seat (META-427).
    */
   popSessionWaitlist: async ({
     sessionId,
@@ -91,36 +102,59 @@ export const sessionRsvpsService = {
   }) => {
     const supabase = createServiceClient()
 
-    const { data, error } = await supabase
-      .from('session_rsvps')
-      .select(
-        'user_id, user:profiles!session_rsvps_user_id_fkey ( team ), created_at',
-      )
-      .eq('session_id', sessionId)
-      .eq('on_waitlist', true)
-      .order('created_at', { ascending: true })
-    if (error) {
-      throw new Error(error.message)
+    const promoted: string[] = []
+    // Rows a concurrent promoter took from under us. They are no longer
+    // waitlisted, so re-attempting them can never succeed.
+    const lost = new Set<string>()
+
+    let passes = 0
+    while (promoted.length < limit && passes < limit + MAX_LOST_PASSES) {
+      passes++
+      const { data, error } = await supabase
+        .from('session_rsvps')
+        .select(
+          'user_id, user:profiles!session_rsvps_user_id_fkey ( team ), created_at',
+        )
+        .eq('session_id', sessionId)
+        .eq('on_waitlist', true)
+        .order('created_at', { ascending: true })
+      if (error) {
+        throw new Error(error.message)
+      }
+      // Filter by team in JS (as countGoingForTeam does): a PostgREST .eq() on
+      // an embedded resource nulls the embed on non-matching rows instead of
+      // filtering parent rows, so `limit` must also apply after the filter.
+      const candidates = data
+        .filter((row) => !lost.has(row.user_id))
+        .filter((row) => !team || row.user.team === team)
+        .slice(0, limit - promoted.length)
+      if (candidates.length === 0) {
+        break
+      }
+
+      const userIds = candidates.map((row) => row.user_id)
+      const { data: claimed, error: updateError } = await supabase
+        .from('session_rsvps')
+        .update({ on_waitlist: false })
+        .in('user_id', userIds)
+        .eq('session_id', sessionId)
+        .eq('on_waitlist', true)
+        .select('user_id')
+      if (updateError) {
+        throw new Error(updateError.message)
+      }
+
+      const claimedIds = new Set(claimed.map((row) => row.user_id))
+      for (const userId of userIds) {
+        if (claimedIds.has(userId)) {
+          promoted.push(userId)
+        } else {
+          lost.add(userId)
+        }
+      }
     }
-    // Filter by team in JS (as countGoingForTeam does): a PostgREST .eq() on an
-    // embedded resource nulls the embed on non-matching rows instead of
-    // filtering parent rows, so `limit` must also apply after the filter.
-    const candidates = (
-      team ? data.filter((row) => row.user.team === team) : data
-    ).slice(0, limit)
-    if (candidates.length === 0) {
-      return [] as string[]
-    }
-    const userIds = candidates.map((row) => row.user_id)
-    const { error: updateError } = await supabase
-      .from('session_rsvps')
-      .update({ on_waitlist: false })
-      .in('user_id', userIds)
-      .eq('session_id', sessionId)
-    if (updateError) {
-      throw new Error(updateError.message)
-    }
-    return userIds
+
+    return promoted
   },
   /** Un-RSVP a user from a session. If they were not on the waitlist, tries to pop the earlier waitlist user off waitlist. */
   unrsvpUserFromSession: async ({

--- a/lib/db/sudoku.ts
+++ b/lib/db/sudoku.ts
@@ -12,14 +12,6 @@ export type SolveSudokuResponse = {
   sudoku: Pick<DbSudoku, 'title' | 'solved_orange' | 'solved_purple'>
 }
 export const sudokuService = {
-  getSudokuSolutions: async () => {
-    const supabase = createServiceClient()
-    const { data, error } = await supabase.from('sudoku').select('*')
-    if (error) {
-      throw new Error(error.message)
-    }
-    return data
-  },
   getSudokus: async () => {
     const supabase = createServiceClient()
     const { data, error } = await supabase
@@ -63,48 +55,56 @@ export const sudokuService = {
     solution: string
     team: DbTeamColor | null
   }): Promise<SolveSudokuResponse> => {
-    const supabase = createServiceClient()
     const sudoku = await sudokuService.getSudokuByTitle(title)
     if (!sudoku) {
       throw new Error('Sudoku not found')
     }
-    if (sudoku.solution !== solution) {
-      return {
-        solved: false,
-        isFirstSolve: false,
-        sudoku: {
-          title: sudoku.title,
-          solved_orange: sudoku.solved_orange,
-          solved_purple: sudoku.solved_purple,
-        },
-      }
+    const currentFlags = {
+      title: sudoku.title,
+      solved_orange: sudoku.solved_orange,
+      solved_purple: sudoku.solved_purple,
     }
-    const newSolvedOrange = sudoku.solved_orange || team === 'orange'
-    const newSolvedPurple = sudoku.solved_purple || team === 'purple'
-    const isFirstSolve =
-      (team === 'orange' && !sudoku.solved_orange) ||
-      (team === 'purple' && !sudoku.solved_purple)
-    const { data, error } = await supabase
-      .from('sudoku')
-      .update({
-        solution,
-        solved_orange: newSolvedOrange,
-        solved_purple: newSolvedPurple,
-      })
+    if (sudoku.solution !== solution) {
+      return { solved: false, isFirstSolve: false, sudoku: currentFlags }
+    }
+    if (team !== 'orange' && team !== 'purple') {
+      // Correct, but there is no territory for this team to claim.
+      return { solved: true, isFirstSolve: false, sudoku: currentFlags }
+    }
+
+    // Compare-and-swap: flip only this team's flag, and only while it is still
+    // false. Writing the single column instead of the whole row read a moment
+    // ago is what stops one team's solve from erasing the other's, and a
+    // returned row means this request is the one that flipped it (META-428).
+    const table = createServiceClient().from('sudoku')
+    const claim =
+      team === 'orange'
+        ? table.update({ solved_orange: true }).eq('solved_orange', false)
+        : table.update({ solved_purple: true }).eq('solved_purple', false)
+    const { data, error } = await claim
       .eq('title', title)
-      .select()
-      .single()
+      .select('title, solved_orange, solved_purple')
+      .maybeSingle()
     if (error) {
       throw new Error(error.message)
     }
+    if (data) {
+      return { solved: true, isFirstSolve: true, sudoku: data }
+    }
+
+    // Someone on this team already claimed it — re-read so the caller sees the
+    // other team's flag as of now rather than as of our stale read.
+    const settled = await sudokuService.getSudokuByTitle(title)
     return {
       solved: true,
-      isFirstSolve,
-      sudoku: {
-        title: data.title,
-        solved_orange: data.solved_orange,
-        solved_purple: data.solved_purple,
-      },
+      isFirstSolve: false,
+      sudoku: settled
+        ? {
+            title: settled.title,
+            solved_orange: settled.solved_orange,
+            solved_purple: settled.solved_purple,
+          }
+        : currentFlags,
     }
   },
 }


### PR DESCRIPTION
Waitlist promotion and sudoku first-solve were both read-then-write races: promotion updated `on_waitlist: false` with no predicate and never checked what it changed (two concurrent cancellations promoted the same person and stranded a seat, META-427), and `solveSudoku` read both teams' flags, OR'd them in JS and wrote the whole row back, so one team's solve erased the other's (META-428). Both now compare-and-swap in application code — promotion claims only rows still `on_waitlist` and retries the next person in a bounded loop; the sudoku update flips only its own column and only while that column is still false, which also makes `isFirstSolve` mean "this request flipped it".

- Dropped the no-op write of the submitted `solution` back into the answer column.
- Deleted `getSudokuSolutions` — it selected the answer key and had zero callers.

**These are mitigations, not fixes.** The read that decides *how many* seats are open (`countGoing` / `countGoingForTeam`) is still a separate round trip, so an RSVP landing between the count and the promotion can still overfill; the CAS only guarantees we never promote the same person twice or lose a team's solve. The durable fix for both is still open and needs DB access:

- META-427: a `SECURITY DEFINER` `promote_waitlist(session_id, limit)` doing select-for-update + update in one statement, ideally folded into META-412's function so the capacity check and the promotion share one transaction.
- META-428: a `SECURITY DEFINER` doing `update sudoku set solved_orange = solved_orange or $x ... returning`. `sudoku` has no migration in the repo (created via the dashboard), so this has to be written against the live schema.

No local typecheck, lint, or build was run — no `node_modules` in this worktree.

## Testing required

- On a session with a waitlist: RSVP, cancel, and confirm the right person is promoted and the going/waitlist counts are correct. The retry loop in `popSessionWaitlist` is the risky part of this change — exercise both a regular session and a megagame (per-team) session, and a cancellation when the waitlist is empty.
- Confirm the hourly `repair-waitlists` cron still succeeds and the admin waitlist-repair tool still reports promotions.
- Solve a sudoku as each team: territory is still claimed, the "you claimed territory" toast appears once per team, and a second solver on the same team gets the plain "Correct!" toast.