### PR TITLE
Close three authorization holes [META-422] [META-423] [META-426]

### DIFF
--- a/app/admin/tools/user-teams/UserTeamsClient.tsx
+++ b/app/admin/tools/user-teams/UserTeamsClient.tsx
@@ -33,6 +33,14 @@ import { ApiAllFullProfilesResponse } from '@/app/api/queries/profiles/route'
 
 import { DbTeamColor } from '@/types/database/dbTypeAliases'
 
+/** Green doubles as the staff team in utils/security.ts, so putting someone on
+ * it also hands them check-in and the ticket roster. Nothing about a team
+ * dropdown says that, hence the interstitial. */
+const confirmGreenAssignment = (userCount: number) =>
+  confirm(
+    `Green is the staff team. Assigning it grants check-in access, the full ticket roster including purchaser emails, the ability to un-RSVP any attendee, and declaring megagame winners.\n\nAssign green to ${userCount} user${userCount === 1 ? '' : 's'}?`,
+  )
+
 export default function UserTeamsClient() {
   const queryClient = useQueryClient()
   const { data: profiles = [], isLoading } = useQuery({
@@ -103,6 +111,14 @@ export default function UserTeamsClient() {
     }
   }
 
+  // This table reads ['profiles']; useProfiles caches team badges elsewhere
+  // under ['users', 'profiles', ...]
+  const invalidateProfiles = () =>
+    Promise.all([
+      queryClient.invalidateQueries({ queryKey: ['profiles'] }),
+      queryClient.invalidateQueries({ queryKey: ['users', 'profiles'] }),
+    ])
+
   const updateOne = useMutation({
     mutationFn: async ({
       userId,
@@ -111,15 +127,11 @@ export default function UserTeamsClient() {
       userId: string
       team: DbTeamColor
     }) => adminUpdateUserProfile({ userId, data: { team } }),
-    onSuccess: (_, variables) => {
-      queryClient.invalidateQueries({
-        queryKey: ['users', 'profiles', variables.userId],
-        exact: false,
-      })
-    },
+    onSuccess: invalidateProfiles,
   })
 
   const handleSetTeam = async (userId: string, team: DbTeamColor) => {
+    if (team === 'green' && !confirmGreenAssignment(1)) return
     setBusy(true)
     try {
       await updateOne.mutateAsync({ userId, team })
@@ -138,6 +150,7 @@ export default function UserTeamsClient() {
     if (bulkTeam === '') return
     const ids = Array.from(selectedIds)
     if (ids.length === 0) return
+    if (bulkTeam === 'green' && !confirmGreenAssignment(ids.length)) return
     setBusy(true)
     try {
       await Promise.all(
@@ -145,13 +158,17 @@ export default function UserTeamsClient() {
           adminUpdateUserProfile({ userId, data: { team: bulkTeam } }),
         ),
       )
-      await queryClient.invalidateQueries({
-        queryKey: ['users', 'profiles'],
-        exact: false,
-      })
       setSelectedIds(new Set())
       setBulkTeam('')
+      toast.success(`Assigned ${ids.length} users to ${bulkTeam}`)
+    } catch {
+      // Promise.all rejects on the first failure while the rest may still have
+      // landed, so keep the selection and let the refetch show what stuck
+      toast.error(
+        `Failed to assign some of the ${ids.length} selected users to ${bulkTeam}`,
+      )
     } finally {
+      await invalidateProfiles()
       setBusy(false)
     }
   }
@@ -209,7 +226,7 @@ export default function UserTeamsClient() {
               <SelectContent>
                 {TEAM_COLORS_ENUM.map((t) => (
                   <SelectItem key={t} value={t}>
-                    {t}
+                    {t === 'green' ? 'green (staff access)' : t}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/app/schedule/ScheduleProvider.tsx
+++ b/app/schedule/ScheduleProvider.tsx
@@ -87,7 +87,6 @@ export default async function ScheduleProvider({
     const sessions = queryClient.getQueryData<DbFullSession[]>(['sessions'])
     if (sessions) {
       editPermissions = await getUserEditPermissionsForSessions({
-        userId: user.id,
         sessionIds: sessions.map((s) => s.id),
       })
     }

--- a/app/schedule/actions.ts
+++ b/app/schedule/actions.ts
@@ -10,78 +10,23 @@ import { createClient } from '@/utils/supabase/server'
 
 import { DbSession, DbSessionUpdate } from '@/types/database/dbTypeAliases'
 
-export async function userCanEditSession({
-  userId,
-  sessionId,
-}: {
-  userId: string
-  sessionId: string
-}) {
-  //Admins can edit any session
-  if (await usersService.getUserAdminStatus({ userId })) {
-    return true
-  }
-
-  const session = await sessionsService.getSessionById({ sessionId })
-  if (!session) {
-    return false
-  }
-  //Hosts can edit sessions
-  if (
-    [session.host_1_id, session.host_2_id, session.host_3_id].includes(userId)
-  ) {
-    return true
-  }
-
-  return false
-}
-
-// Fields that users can update on sessions; for admins editing sessinos more generally, we use adminUpdateSession
-const sessionUpdateSchema = z.object({
-  title: z.string().min(1).optional(),
-  description: z.string().optional().nullable(),
-  needs: z.string().optional().nullable(),
-  // nullish, not optional: the edit modal sends explicit nulls for unset capacities
-  min_capacity: z.number().min(1).nullish(),
-  max_capacity: z.number().min(1).nullish(),
-  ages: z.enum(SESSION_AGES).optional(),
-  category: z.enum(SESSION_CATEGORIES).nullish(),
-})
-export async function userEditSession({
-  sessionId,
-  sessionUpdate,
-}: {
-  sessionId: DbSession['id']
-  sessionUpdate: DbSessionUpdate
-}) {
+async function requireCurrentUserId() {
   const supabase = await createClient()
   const {
-    data: { user: currentUser },
-    error: currentUserError,
+    data: { user },
+    error,
   } = await supabase.auth.getUser()
-  if (currentUserError || !currentUser) {
+  if (error || !user) {
     throw new Error('User not authenticated')
   }
-
-  // Check permissions using the efficient method
-  const permissions = await getUserEditPermissionsForSessions({
-    userId: currentUser.id,
-    sessionIds: [sessionId],
-  })
-
-  if (!permissions[sessionId]) {
-    throw new Error('Unauthorized')
-  }
-
-  //extract only the values that a user can edit
-  const validatedSessionUpdate = sessionUpdateSchema.parse(sessionUpdate)
-  await sessionsService.updateSession({
-    sessionId,
-    payload: validatedSessionUpdate,
-  })
+  return user.id
 }
 
-export async function getUserEditPermissionsForSessions({
+/** Deliberately not exported: every export of a `'use server'` module is a
+ * POST-callable endpoint, so anything taking a caller-supplied userId has to
+ * stay private and be reached through a wrapper that derives the id from the
+ * session. */
+async function editPermissionsForUser({
   userId,
   sessionIds,
 }: {
@@ -117,4 +62,52 @@ export async function getUserEditPermissionsForSessions({
   }
 
   return permissions
+}
+
+// Fields that users can update on sessions; for admins editing sessinos more generally, we use adminUpdateSession
+const sessionUpdateSchema = z.object({
+  title: z.string().min(1).optional(),
+  description: z.string().optional().nullable(),
+  needs: z.string().optional().nullable(),
+  // nullish, not optional: the edit modal sends explicit nulls for unset capacities
+  min_capacity: z.number().min(1).nullish(),
+  max_capacity: z.number().min(1).nullish(),
+  ages: z.enum(SESSION_AGES).optional(),
+  category: z.enum(SESSION_CATEGORIES).nullish(),
+})
+export async function userEditSession({
+  sessionId,
+  sessionUpdate,
+}: {
+  sessionId: DbSession['id']
+  sessionUpdate: DbSessionUpdate
+}) {
+  const userId = await requireCurrentUserId()
+
+  // Check permissions using the efficient method
+  const permissions = await editPermissionsForUser({
+    userId,
+    sessionIds: [sessionId],
+  })
+
+  if (!permissions[sessionId]) {
+    throw new Error('Unauthorized')
+  }
+
+  //extract only the values that a user can edit
+  const validatedSessionUpdate = sessionUpdateSchema.parse(sessionUpdate)
+  await sessionsService.updateSession({
+    sessionId,
+    payload: validatedSessionUpdate,
+  })
+}
+
+/** Edit permissions for the signed-in caller; throws when there's no session. */
+export async function getUserEditPermissionsForSessions({
+  sessionIds,
+}: {
+  sessionIds: string[]
+}) {
+  const userId = await requireCurrentUserId()
+  return editPermissionsForUser({ userId, sessionIds })
 }

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -8,6 +8,9 @@ import {
   DbTeamColor,
 } from '@/types/database/dbTypeAliases'
 
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
 const sessionsSelectIncludes = `
 *,
 host_1:profiles!sessions_host_1_id_fkey (
@@ -77,6 +80,12 @@ export const sessionsService = {
 
   /** Get all sessions hosted by a user */
   getSessionsHostedByUser: async ({ userId }: { userId: string }) => {
+    // The .or() below interpolates userId into raw PostgREST filter syntax on a
+    // service-role client, so anything but a literal uuid would let the caller
+    // append filters of their own.
+    if (!UUID_PATTERN.test(userId)) {
+      throw new Error('Invalid user id')
+    }
     const supabase = createServiceClient()
     const { data, error } = await supabase
       .from('sessions')

--- a/lib/db/storage.ts
+++ b/lib/db/storage.ts
@@ -1,13 +1,28 @@
 import { createServiceClient } from '@/utils/supabase/service'
 
+const ALLOWED_UPLOAD_CONTENT_TYPES = [
+  'image/gif',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]
+
 export const storageService = {
-  /** Get a signed URL for uploading a file */
+  /** Get a signed URL for uploading a file.
+   *
+   * fileType gates whether a URL is issued at all. It can't constrain the
+   * Content-Type the client eventually PUTs — supabase-js signed upload URLs
+   * only carry the path and the upsert flag — so the bucket's
+   * allowed_mime_types is the only real write-time enforcement. Keep the set
+   * of signable paths fixed rather than trusting either. */
   getSignedUploadUrl: async (
     bucket: string,
     path: string,
     fileType: string,
   ) => {
-    console.log('getSignedUploadUrl', bucket, path, fileType)
+    if (!ALLOWED_UPLOAD_CONTENT_TYPES.includes(fileType)) {
+      throw new Error(`Unsupported upload content type: ${fileType}`)
+    }
     const supabase = createServiceClient()
     const { data, error } = await supabase.storage
       .from(bucket)
@@ -35,17 +50,16 @@ export const storageService = {
     const { data } = supabase.storage.from(bucket).getPublicUrl(path)
     return data.publicUrl
   },
-  getUserProfilePictureUploadUrl: async ({
-    userId,
-    fileExtension,
-  }: {
-    userId: string
-    fileExtension?: string
-  }) => {
+  getUserProfilePictureUploadUrl: async ({ userId }: { userId: string }) => {
     const bucket = 'public-assets'
-    const extension = fileExtension ? `.${fileExtension}` : ''
-    const path = `profile_pictures/${userId}${extension}`
-    const url = await storageService.getSignedUploadUrl(bucket, path, 'image/*')
+    // Fixed, extensionless key: the caller gets no say in what it can write to,
+    // and canonicalUserProfilePictureUrl() in lib/utils reconstructs this path.
+    const path = `profile_pictures/${userId}`
+    const url = await storageService.getSignedUploadUrl(
+      bucket,
+      path,
+      'image/webp',
+    )
     return {
       signedUrl: url.signedUrl,
       storageUrl:

--- a/lib/db/users.ts
+++ b/lib/db/users.ts
@@ -113,7 +113,9 @@ export const usersService = {
       .from('profiles')
       .select('is_admin')
       .eq('id', userId)
-      .single() // Error if we dont find the user because why not
+      // maybeSingle, not single: throwing only for ids that don't exist turns
+      // this into a user-existence oracle
+      .maybeSingle()
     if (error) {
       throw new Error(error.message)
     }
@@ -188,17 +190,6 @@ export const usersService = {
     return data satisfies DbFullProfile | null
   },
 
-  /** Get a signed URL for uploading a user's profile picture */
-  getProfilePictureUploadUrl: async ({ userId }: { userId: string }) => {
-    const bucket = 'public-assets'
-    const path = `profile_pictures/${userId}`
-    const signedUrl = await storageService.getSignedUploadUrl(
-      bucket,
-      path,
-      'image/*',
-    )
-    return signedUrl
-  },
   deleteProfilePicture: async ({ userId }: { userId: string }) => {
     await storageService.deleteUserProfilePicture({ userId })
     await usersService.updateUserProfile({


### PR DESCRIPTION
Three unrelated authorization-surface fixes, all in the same area of "application code is the only access control": the schedule server actions ([META-422]), profile-picture upload URLs ([META-423]), and the bulk team-assign tool ([META-426]).

- **META-422** — `app/schedule/actions.ts` carries `'use server'`, so every export is a POST-callable endpoint. Deleted the zero-call-site `userCanEditSession`, moved the permission computation into a private helper, and made both remaining exports derive the caller from the session instead of a `userId` argument. Also guarded the `userId` that `getSessionsHostedByUser` interpolates into a PostgREST `.or()` filter on a service-role client, and switched `getUserAdminStatus` to `maybeSingle()` so a nonexistent id no longer throws.
- **META-423** — dropped `fileExtension` from `getUserProfilePictureUploadUrl` (both real call sites already passed nothing), so a signed PUT is always for `profile_pictures/<uid>`. `getSignedUploadUrl` now allowlists the content type it will sign for, and no longer logs bucket/path.
- **META-426** — took the smaller fix: added the missing `catch` in `handleBulkAssign` and a confirmation before assigning green. Drive-bys: bulk assign now toasts on success, and both handlers invalidate `['profiles']` (the key this table actually reads) alongside the existing `['users', 'profiles']`.

## Known limitations / follow-ups

- **META-426 is not really fixed.** Decoupling staff privilege from megagame team — moving it onto the existing `volunteer` column, per the issue — is a schema + data migration, and worth doing. Until then green membership is still a privilege grant; this PR only makes granting it deliberate and makes failures visible.
- **META-423 content-type is gated, not enforced.** supabase-js signed upload URLs only carry the path and the upsert flag, so the allowlist decides whether a URL is issued but cannot constrain the `Content-Type` the client ultimately PUTs. The durable fix is `allowed_mime_types` on the `public-assets` bucket, which is a dashboard/ops change outside this repo. The arbitrary-key write is fully closed either way.

## Testing required

No local typecheck, lint, or build was run (no `node_modules` on this box) — CI and the preview are the gate.

- **Session editing still works for a legitimate host.** The auth change is the one most likely to over-restrict: `getUserEditPermissionsForSessions` now throws for anonymous callers and ignores any passed-in id. Sign in as a non-admin session host, confirm the schedule still shows edit affordances on their own sessions and that saving an edit works; confirm an admin can still edit any session; confirm the schedule renders for a logged-out visitor.
- **Profile picture upload works end to end** — both `/profile` and the admin profile editor. The storage key is unchanged in practice, but `getSignedUploadUrl` now throws on an unrecognized content type.
- **Bulk team assignment works and surfaces errors.** Assign a couple of users to orange/purple; confirm the table updates. Confirm the green confirmation appears from both the bulk dropdown and a single-row dropdown, and that cancelling leaves the team unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012PPepDLatLzfSBuBxxsuiU