### PR TITLE
Gate megagame card rewards on the winning team, make claims atomic [META-419]

### DIFF
--- a/app/actions/db/sessions.ts
+++ b/app/actions/db/sessions.ts
@@ -45,14 +45,22 @@ export const authedDeclareWinningTeam = async ({
   if (!authed) {
     throw new Error('You are not authorized to declare the winning team')
   }
-  const winnerUserIds = session.rsvps
-    .filter((rsvp) => !rsvp.on_waitlist)
-    .map((rsvp) => rsvp.user_id)
-  await sessionsService.declareWinningTeam({ sessionId, winningTeam })
-  await playerCardClaimsService.createOpenPlayerCardClaims({
-    userIds: winnerUserIds,
+  const declaredSession = await sessionsService.declareWinningTeam({
     sessionId,
+    winningTeam,
   })
+  if (!declaredSession) {
+    throw new Error('A winning team has already been declared for this session')
+  }
+  const winnerUserIds = session.rsvps
+    .filter((rsvp) => !rsvp.on_waitlist && rsvp.user?.team === winningTeam)
+    .map((rsvp) => rsvp.user_id)
+  if (winnerUserIds.length > 0) {
+    await playerCardClaimsService.createOpenPlayerCardClaims({
+      userIds: winnerUserIds,
+      sessionId,
+    })
+  }
 }
 
 /* Queries */

--- a/app/actions/db/tickets.ts
+++ b/app/actions/db/tickets.ts
@@ -73,7 +73,25 @@ export const signupByTicketCode = async ({
     }
     userId = user.id
   }
-  await ticketsService.updateTicketOwner({ ticketCode, ownerId: userId })
+  const claimedTicket = await ticketsService.updateTicketOwner({
+    ticketCode,
+    ownerId: userId,
+  })
+  if (!claimedTicket) {
+    if (!existingUser) {
+      /* We only signed this account up to hold the ticket, so losing the race
+       * would otherwise strand an account with no ticket behind it. */
+      try {
+        await usersService.fullDeleteUser({ userId })
+      } catch (cleanupError) {
+        console.error(
+          'Failed to remove signup after a lost ticket claim',
+          cleanupError,
+        )
+      }
+    }
+    return { success: false, error: 'claimed', ticket: null }
+  }
   // Teams are assigned once. Claiming another ticket must not reroll the team of
   // someone who already has one.
   const profile =
@@ -88,7 +106,7 @@ export const signupByTicketCode = async ({
       },
     })
   }
-  return { success: true, error: null, ticket: ticket }
+  return { success: true, error: null, ticket: claimedTicket }
 }
 export const volunteerGetAllFullTickets = async () => {
   await assertAuthLevel({ authLevel: 'VOLUNTEER' })

--- a/app/actions/db/users.ts
+++ b/app/actions/db/users.ts
@@ -6,7 +6,10 @@ import {
   currentUserWrapper,
 } from './auth'
 
-import { playerCardClaimsService } from '@/lib/db/playerCardClaims'
+import {
+  CARD_CLAIM_WINDOW_MS,
+  playerCardClaimsService,
+} from '@/lib/db/playerCardClaims'
 import { sessionsService } from '@/lib/db/sessions'
 import { usersService } from '@/lib/db/users'
 import {
@@ -104,7 +107,6 @@ export const currentUserSelectCardReward = currentUserWrapper(
     celestialCardId: number
     sessionId: string
   }) => {
-    // look up which team won session and check that user is on that team and rsvpd to that session
     const session = await sessionsService.getSessionById({ sessionId })
     if (!session) {
       throw new Error('Session not found. Please refresh and try again.')
@@ -119,6 +121,11 @@ export const currentUserSelectCardReward = currentUserWrapper(
     if (!userProfile) {
       throw new Error('User profile not found. Please refresh and try again.')
     }
+    if (userProfile.team !== winningTeam) {
+      throw new Error(
+        'Card rewards for this session are only available to the winning team.',
+      )
+    }
     const userCardClaim =
       await playerCardClaimsService.getPlayerCardClaimsByUserIdAndSessionId({
         userId,
@@ -132,29 +139,37 @@ export const currentUserSelectCardReward = currentUserWrapper(
         'You have already claimed a card reward for this session.',
       )
     }
-    const cardRewards = session.card_rewards
-    // verify that the card is in the list of allowed card rewards or the user is keeping their current celestial card
+    const claimAge = Date.now() - new Date(userCardClaim.created_at).getTime()
+    if (claimAge > CARD_CLAIM_WINDOW_MS) {
+      throw new Error('The window to claim this card reward has closed.')
+    }
+    // The card must be one this session offers, or the one the user already has
+    const keepingCurrentCard =
+      userProfile.celestial_card_id !== null &&
+      celestialCardId === userProfile.celestial_card_id
     if (
-      !cardRewards.map((card) => card.id).includes(celestialCardId) &&
-      !(celestialCardId == userProfile.celestial_card_id)
+      !keepingCurrentCard &&
+      !session.card_rewards.some((card) => card.id === celestialCardId)
     ) {
       throw new Error(
         'The selected card is not available as a reward for this session.',
       )
     }
-    return playerCardClaimsService.makePlayerCardClaim({
+    const claim = await playerCardClaimsService.makePlayerCardClaim({
       userId,
       sessionId,
       newCardId: celestialCardId,
     })
+    if (!claim) {
+      throw new Error(
+        'You have already claimed a card reward for this session.',
+      )
+    }
+    return claim
   },
 )
 
-export const currentUserLatestUnclaimedVictory = async ({
-  timeWindow,
-}: {
-  timeWindow: number
-}) => {
+export const currentUserLatestUnclaimedVictory = async () => {
   const user = await usersService.getCurrentUser()
   if (!user) {
     return null
@@ -162,7 +177,7 @@ export const currentUserLatestUnclaimedVictory = async ({
   const playerCardClaims =
     await playerCardClaimsService.getOpenPlayerCardClaimsByPlayerId({
       userId: user.id,
-      timeWindow,
+      timeWindow: CARD_CLAIM_WINDOW_MS,
     })
   if (playerCardClaims.length === 0) {
     return null

--- a/components/PickACard/CardPicker.tsx
+++ b/components/PickACard/CardPicker.tsx
@@ -28,6 +28,10 @@ export default function CardPicker({
   const [showConfirmation, setShowConfirmation] = useState(false)
   const [open, setOpen] = useState(true)
   const router = useRouter()
+  /* Redeeming a claim means recording the chosen card id, so "keep current" is
+   * only offerable to someone who already has a card to keep. */
+  const canKeepCurrentCard = user.celestial_card_id !== null
+  const cardIdToClaim = selectedCard?.id ?? user.celestial_card_id
 
   const { selectCard, isSelecting } = useCardSelection({
     userId: user.id,
@@ -78,34 +82,36 @@ export default function CardPicker({
             </div>
           </DialogDescription>
           <div className="grid max-h-[70vh] grid-cols-2 gap-4 self-center overflow-y-auto sm:grid-cols-4">
-            <div
-              role="button"
-              tabIndex={0}
-              aria-label="Keep your current card"
-              className="flex w-fit cursor-pointer flex-col items-center justify-center bg-celestial-gold p-2 transition-colors hover:bg-celestial-gold/80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
-              onClick={() => {
-                setSelectedCard(null)
-                setShowConfirmation(true)
-              }}
-              onKeyDown={(e) => {
-                if (e.target !== e.currentTarget) return
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault()
+            {canKeepCurrentCard && (
+              <div
+                role="button"
+                tabIndex={0}
+                aria-label="Keep your current card"
+                className="flex w-fit cursor-pointer flex-col items-center justify-center bg-celestial-gold p-2 transition-colors hover:bg-celestial-gold/80 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
+                onClick={() => {
                   setSelectedCard(null)
                   setShowConfirmation(true)
-                }
-              }}
-            >
-              <span className="text-sm text-celestial-primary sm:text-xl">
-                Keep Current
-              </span>
-              <PlayerCard
-                userId={user.id}
-                asCelestialCard={true}
-                overrideCelestialCard={null}
-                width={150}
-              />
-            </div>
+                }}
+                onKeyDown={(e) => {
+                  if (e.target !== e.currentTarget) return
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault()
+                    setSelectedCard(null)
+                    setShowConfirmation(true)
+                  }
+                }}
+              >
+                <span className="text-sm text-celestial-primary sm:text-xl">
+                  Keep Current
+                </span>
+                <PlayerCard
+                  userId={user.id}
+                  asCelestialCard={true}
+                  overrideCelestialCard={null}
+                  width={150}
+                />
+              </div>
+            )}
             {cards.map((card) => (
               <div
                 key={card.id}
@@ -190,22 +196,13 @@ export default function CardPicker({
             </Button>
             <Button
               onClick={() => {
-                if (selectedCard) {
-                  selectCard({
-                    sessionId: session.id,
-                    celestialCardId: selectedCard.id,
-                  })
-                } else {
-                  selectCard({
-                    sessionId: session.id,
-                    celestialCardId:
-                      user.celestial_card_id == null
-                        ? 9999
-                        : user.celestial_card_id,
-                  })
-                }
+                if (cardIdToClaim === null) return
+                selectCard({
+                  sessionId: session.id,
+                  celestialCardId: cardIdToClaim,
+                })
               }}
-              disabled={isSelecting}
+              disabled={isSelecting || cardIdToClaim === null}
             >
               {isSelecting ? 'Selecting...' : 'Confirm'}
             </Button>

--- a/components/PickACard/PickACardMetaProvider.tsx
+++ b/components/PickACard/PickACardMetaProvider.tsx
@@ -3,9 +3,7 @@ import PickACard from './PickACardProvider'
 import { currentUserLatestUnclaimedVictory } from '@/app/actions/db/users'
 
 export default async function PickACardMetaProvider() {
-  const unclaimedVictory = await currentUserLatestUnclaimedVictory({
-    timeWindow: 1000 * 60 * 60 * 24 * 5,
-  })
+  const unclaimedVictory = await currentUserLatestUnclaimedVictory()
   if (!unclaimedVictory) {
     return null
   }

--- a/lib/db/playerCardClaims.ts
+++ b/lib/db/playerCardClaims.ts
@@ -1,5 +1,9 @@
 import { createServiceClient } from '@/utils/supabase/service'
 
+/** How long after a win a player has to redeem their card reward. Server-owned:
+ * it used to arrive as a caller-supplied argument. */
+export const CARD_CLAIM_WINDOW_MS = 1000 * 60 * 60 * 24 * 5
+
 export const playerCardClaimsService = {
   getPlayerCardClaims: async ({ userId }: { userId: string }) => {
     const supabase = createServiceClient()
@@ -26,6 +30,11 @@ export const playerCardClaimsService = {
       .select('*')
       .eq('user_id', userId)
       .eq('session_id', sessionId)
+      /* Tolerate duplicate rows: nothing enforces uniqueness on
+       * (user_id, session_id), and a bare .maybeSingle() errors on more than
+       * one row, locking every attendee of that session out of claiming. */
+      .order('created_at', { ascending: false })
+      .limit(1)
       .maybeSingle()
     if (error) {
       throw new Error(error.message)
@@ -106,7 +115,8 @@ export const playerCardClaimsService = {
     }
     return data
   },
-  /** Does NOT do the validation of card choice */
+  /** Does NOT do the validation of card choice. Returns null if the claim was
+   * already redeemed (e.g. a second browser tab got there first). */
   makePlayerCardClaim: async ({
     userId,
     sessionId,
@@ -117,15 +127,20 @@ export const playerCardClaimsService = {
     newCardId: number
   }) => {
     const supabase = createServiceClient()
-    const { data, error } = await supabase
+    // Compare-and-swap: whoever flips new_card_id off null owns the reward
+    const { data: claims, error } = await supabase
       .from('player_card_claims')
       .update({ new_card_id: newCardId })
       .eq('user_id', userId)
       .eq('session_id', sessionId)
+      .is('new_card_id', null)
       .select()
-      .single()
     if (error) {
       throw new Error(error.message)
+    }
+    const playerCardClaim = claims[0]
+    if (!playerCardClaim) {
+      return null
     }
     const { data: updatedProfile, error: updateError } = await supabase
       .from('profiles')
@@ -134,10 +149,18 @@ export const playerCardClaimsService = {
       .select()
       .single()
     if (updateError) {
+      /* Reopen the claim: otherwise the reward is spent but the card never
+       * landed, and new_card_id being set blocks any retry. */
+      await supabase
+        .from('player_card_claims')
+        .update({ new_card_id: null })
+        .eq('user_id', userId)
+        .eq('session_id', sessionId)
+        .eq('new_card_id', newCardId)
       throw new Error(updateError.message)
     }
     return {
-      playerCardClaim: data,
+      playerCardClaim,
       updatedProfile,
     }
   },

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -164,7 +164,7 @@ export const sessionsService = {
 
     const { data: session, error } = await supabase
       .from('sessions')
-      .select('megagame, winning_team, megagame_location')
+      .select('megagame, megagame_location')
       .eq('id', sessionId)
       .single()
     if (error) {
@@ -173,10 +173,27 @@ export const sessionsService = {
     if (!session.megagame) {
       throw new Error('Session is not a megagame')
     }
-    if (session.winning_team) {
-      throw new Error('Winning team already declared')
+
+    /* Compare-and-swap on winning_team: a read-then-write guard lets two hosts
+     * (or one double-tap) both declare and mint duplicate card claims. */
+    const { data, error: updateError } = await supabase
+      .from('sessions')
+      .update({
+        winning_team: winningTeam,
+        win_timestamp: new Date().toISOString(),
+      })
+      .eq('id', sessionId)
+      .is('winning_team', null)
+      .select()
+      .maybeSingle()
+    if (updateError) {
+      throw new Error(updateError.message)
+    }
+    if (!data) {
+      return null
     }
 
+    // Only once the session row is ours, so the map can't contradict it
     if (session.megagame_location) {
       const { error: locationError } = await supabase
         .from('megagame_locations')
@@ -189,18 +206,6 @@ export const sessionsService = {
       }
     }
 
-    const { data, error: updateError } = await supabase
-      .from('sessions')
-      .update({
-        winning_team: winningTeam,
-        win_timestamp: new Date().toISOString(),
-      })
-      .eq('id', sessionId)
-      .select()
-      .single()
-    if (updateError) {
-      throw new Error(updateError.message)
-    }
     return data
   },
   /** Get a list of sessions whose victory timesamps are within the specified timewindow */

--- a/lib/db/tickets.ts
+++ b/lib/db/tickets.ts
@@ -123,6 +123,9 @@ export const ticketsService = {
     }
     return data
   },
+  /** Claims an unowned ticket. Returns null if someone else already owns it: a
+   * forwarded code can be redeemed by two people at once, and without the
+   * compare-and-swap the last writer wins and both are told they succeeded. */
   updateTicketOwner: async ({
     ticketCode,
     ownerId,
@@ -135,8 +138,9 @@ export const ticketsService = {
       .from('tickets')
       .update({ owner_id: ownerId })
       .eq('ticket_code', ticketCode)
+      .is('owner_id', null)
       .select()
-      .single()
+      .maybeSingle()
     if (error) {
       throw new Error(error.message)
     }


### PR DESCRIPTION
Card rewards were minted for every attendee of a megagame session and redeemed with no team check, so losers earned the same cards as winners; both layers now filter on the winning team. Also fixes META-429: the three read-then-write claim races (ticket `owner_id`, claim `new_card_id`, session `winning_team`) become compare-and-swaps, and the `megagame_locations.control` write moves after the session CAS so the map can't contradict the session.

Other things picked up along the way:

- The 5-day redemption window was a caller-supplied argument to a server action; it is now a server-owned constant (`CARD_CLAIM_WINDOW_MS`) enforced against the claim's `created_at`.
- "Keep current card" sent magic id `9999`, which the server rejected for anyone with a null `celestial_card_id`. The magic number is gone and the option is hidden when there is no card to keep — redeeming a claim means writing a card id, and there is none.
- Losing the ticket-claim race used to leave a real auth account with no ticket. The account we just created is now deleted when the CAS loses.
- If the profile write fails after a card claim is consumed, the claim is reopened so the user can retry.

## Testing required

None of this is verifiable without a database, and no local typecheck/lint/build was run (no `node_modules` on this machine) — **Vercel is the gate**. A human needs to:

1. Declare a winner on a test megagame session with attendees on **both** teams. Confirm only winning-team attendees get a `player_card_claims` row, and that the session's `megagame_location` control matches `winning_team`.
2. Call `currentUserSelectCardReward` directly as a losing-team player and confirm it is rejected.
3. Double-tap "Declare winner" (two tabs / flaky wifi). The second should fail with "already been declared" and must not mint a second round of claims.
4. Double-tap the card picker in two tabs with different cards. One wins; the other gets "already claimed", not a silent overwrite.
5. Claim one forwarded ticket code from two browsers at once. Exactly one succeeds; the loser sees the `claimed` error and leaves no orphaned auth user behind.
6. Sanity-check a user with no `celestial_card_id`: the picker shows no "Keep Current" tile and picking a real card works.

## Follow-up: unique constraint on `player_card_claims`

`player_card_claims` was created through the Supabase dashboard and has **no migration in the repo**, so whether `(user_id, session_id)` is unique cannot be determined from the codebase and could not be checked here (no DB access). This PR deliberately does **not** add an `upsert ... onConflict: 'user_id,session_id'`, which would fail at runtime if the constraint does not exist.

The CAS on `winning_team` prevents duplicate claim rows at the source either way, and `getPlayerCardClaimsByUserIdAndSessionId` now orders + `limit(1)`s so any duplicates *already* in production degrade to "picks the newest" instead of erroring out and bricking card-claiming for every attendee of that session. Confirming the constraint still wants `\d player_card_claims` against prod, and adding it (plus a migration) if it is missing.

## Note on `loser_option`

META-419 asks both for "only winners get a claim" and for the server to honour the `loser_option` restriction the UI applies to losers. Those are mutually exclusive: with winners-only claims, a losing player never has a claim row to redeem, so a loser-option code path is unreachable. I implemented the winners-only policy (which is what the issue's own verification step asks for) and did not add a dead `loser_option` branch. The matching branch in `CardPicker`'s `useMemo` is now unreachable too — left in place rather than churning the component, but worth deleting if the policy is confirmed.