### PR TITLE
[META-418] Fix BTC ticket confirmation emails; stop trusting the OpenNode webhook body

### DIFF
--- a/app/api/checkout/opennode/route.ts
+++ b/app/api/checkout/opennode/route.ts
@@ -108,7 +108,7 @@ export async function POST(req: NextRequest) {
   return NextResponse.json({ charge })
 }
 
-function sendChargeCreationEmail(
+async function sendChargeCreationEmail(
   charge: OpenNodeCharge,
   ticketDetails: TicketPurchaseDetails,
 ) {
@@ -116,7 +116,7 @@ function sendChargeCreationEmail(
   const amountBtc = (charge.amount / 100000000).toFixed(6)
   const hostedUrl = getHostedCheckoutUrl(charge.id)
 
-  return resend.emails.send({
+  const { data, error } = await resend.emails.send({
     from: 'Metagame 2025 <tickets@mail.metagame.games>',
     to: ticketDetails.purchaserEmail,
     bcc: ['team@metagame.games'],
@@ -175,4 +175,10 @@ See you at Metagame 2025!
 This is not a puzzle.
     `.trim(),
   })
+
+  // Resend reports API-level failures in the payload, not by rejecting.
+  if (error) {
+    throw error
+  }
+  return data
 }

--- a/app/api/checkout/opennode/webhook/route.ts
+++ b/app/api/checkout/opennode/webhook/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { OpenNodeChargeWebhook } from 'opennode/dist/types/v1'
+import { OpenNodeCharge, OpenNodeChargeWebhook } from 'opennode/dist/types/v1'
 
 import { opennodeDbService } from '@/lib/db/opennode'
 import { ticketsService } from '@/lib/db/tickets'
@@ -72,13 +72,29 @@ export async function POST(req: NextRequest) {
     return new NextResponse('invalid sig', { status: 400 })
   }
 
+  // signatureIsValid HMACs charge.id and nothing else, so status, amount and
+  // order_id stay attacker-controlled even when the signature checks out.
+  // Re-fetch the charge and act on OpenNode's copy rather than the body.
+  let charge: OpenNodeCharge
+  try {
+    charge = await opennode.chargeInfo(body.id)
+  } catch (error) {
+    console.error('failed to fetch opennode charge', body.id, error)
+    if (!skipSignatureCheck) {
+      // 5xx so OpenNode retries; nothing has been written yet.
+      return new NextResponse('could not fetch charge', { status: 502 })
+    }
+    // Local testing posts synthetic bodies for charges OpenNode never saw.
+    charge = body
+  }
+
   const dbCharge = await opennodeDbService.updateChargeStatus({
-    metagameOrderId: body.order_id,
-    status: body.status,
-    charge: body,
+    metagameOrderId: charge.order_id,
+    status: charge.status,
+    charge,
   })
 
-  if (body.status === 'paid') {
+  if (charge.status === 'paid') {
     // OpenNode retries callbacks, so a ticket must only be minted once per order.
     const existingTicket = await ticketsService.getTicketByOpennodeOrder({
       orderId: dbCharge.id,
@@ -89,7 +105,7 @@ export async function POST(req: NextRequest) {
     }
 
     // Never issue a ticket for less than the charge was created for.
-    const satoshisPaid = body.amount - (body.missing_amt ?? 0)
+    const satoshisPaid = charge.amount - (charge.missing_amt ?? 0)
     if (satoshisPaid < dbCharge.satoshis) {
       console.error(
         'opennode charge marked paid for less than the charge amount',
@@ -111,7 +127,7 @@ export async function POST(req: NextRequest) {
       is_test: dbCharge.is_test,
       satoshis_paid: satoshisPaid,
     }
-    await ticketsService.createTicket({ ticket: newTicket })
+    const dbTicket = await ticketsService.createTicket({ ticket: newTicket })
 
     if (!dbCharge.purchaser_email) {
       console.error('no purchaser email on opennode charge', dbCharge)
@@ -121,18 +137,27 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ received: true })
     }
 
-    await sendTicketConfirmationEmail({
-      to: dbCharge.purchaser_email,
-      purchaserName: dbCharge.purchaser_name || '',
-      ticketType: dbCharge.ticket_type!,
-      ticketCode: dbCharge.id,
-      isBtc: true,
-      btcPaid: body.amount / 100_000_000,
-      opennodeChargeId: dbCharge.id,
-      adminIssued: false,
-      forExistingUser: false,
-      test: dbCharge.is_test,
-    })
+    // The ticket row is already written, so a retry short-circuits on the
+    // idempotency guard above and never re-sends. Alert instead of 500ing.
+    try {
+      await sendTicketConfirmationEmail({
+        to: dbCharge.purchaser_email,
+        purchaserName: dbCharge.purchaser_name || '',
+        ticketType: dbCharge.ticket_type!,
+        ticketCode: dbTicket.ticket_code,
+        isBtc: true,
+        btcPaid: satoshisPaid / 100_000_000,
+        opennodeChargeId: charge.id,
+        adminIssued: false,
+        forExistingUser: false,
+        test: dbCharge.is_test,
+      })
+    } catch (error) {
+      console.error('failed to send ticket confirmation email', error)
+      await sendAdminErrorEmail(
+        `Ticket ${dbTicket.ticket_code} was issued for opennode order ${dbCharge.id} but the confirmation email failed to send: ${error instanceof Error ? error.message : String(error)}`,
+      )
+    }
   }
 
   return NextResponse.json({ received: true })

--- a/lib/db/opennode.ts
+++ b/lib/db/opennode.ts
@@ -1,4 +1,4 @@
-import { OpenNodeCharge, OpenNodeChargeWebhook } from 'opennode/dist/types/v1'
+import { OpenNodeCharge } from 'opennode/dist/types/v1'
 
 import { OpennodeChargeInput } from '@/lib/schemas/opennode'
 
@@ -42,9 +42,28 @@ export const opennodeDbService = {
   }: {
     metagameOrderId: string
     status: DbOpendnodeOrder['status']
-    charge?: OpenNodeChargeWebhook
+    charge?: OpenNodeCharge
   }) => {
     const supabase = createServiceClient()
+    if (charge) {
+      // Checked before the write, not after: an order whose row belongs to a
+      // different charge must not have its status flipped at all.
+      const { data: existing, error: existingError } = await supabase
+        .from('opennode_orders')
+        .select('opennode_order_id')
+        .eq('id', metagameOrderId)
+        .single()
+      if (existingError) {
+        throw new Error(
+          `Error reading opennode order before status update: ${existingError.message}`,
+        )
+      }
+      if (existing.opennode_order_id !== charge.id) {
+        throw new Error(
+          `Opennode order ${metagameOrderId} belongs to charge ${existing.opennode_order_id}, not ${charge.id}`,
+        )
+      }
+    }
     const { data, error } = await supabase
       .from('opennode_orders')
       .update({ status })
@@ -53,15 +72,6 @@ export const opennodeDbService = {
       .single()
     if (error) {
       throw new Error(`Error updating opennode order status: ${error.message}`)
-    }
-    if (data && charge) {
-      if (data.opennode_order_id !== charge.id) {
-        console.error(
-          "Charge's OpenNode charge id didn't match db charge id",
-          data.opennode_order_id,
-          charge.id,
-        )
-      }
     }
     return data
   },

--- a/lib/email.ts
+++ b/lib/email.ts
@@ -41,6 +41,30 @@ export async function sendTicketConfirmationEmail({
     const discordUrl = SOCIAL_LINKS.DISCORD
     const testSubject = test ? 'TEST: ' : ''
     const siteUrl = getSiteUrl()
+    const pricePaid = isBtc
+      ? `₿${btcPaid?.toFixed(6)}`
+      : `$${usdPaid?.toFixed(2)}`
+    const paymentIdLine = isBtc
+      ? `- OpenNode Charge ID: ${opennodeChargeId}`
+      : `- Stripe Payment ID: ${paymentIntentId}`
+    const ticketCodeLine = `- Your Ticket Code: ${ticketCode} (you will need this to create your account and associate the ticket)`
+    // Built as lines rather than inline conditionals so an omitted detail
+    // doesn't leave a blank line (or a stray `false`) in the plaintext part.
+    const textTicketDetails = [
+      `- Ticket Type: ${ticketTypeDetails[ticketType].title}`,
+      ...(adminIssued ? [] : [`- Price Paid: ${pricePaid}`]),
+      ...(forExistingUser ? [] : [ticketCodeLine]),
+      ...(adminIssued ? [] : [paymentIdLine]),
+    ].join('\n')
+    const textNextSteps = forExistingUser
+      ? `Your account already exists and now has an associated ticket. If you haven't logged in before, you can set your password at ${siteUrl}/login/reset?email=${encodeURIComponent(to)}&firstLogin=true`
+      : `Next Steps:
+1. Go to ${siteUrl}/signup?email=${encodeURIComponent(to)}&ticketCode=${ticketCode}
+2. Your email and ticket code will be pre-filled
+3. Create your account and set up your profile (badge name, Discord, etc.)
+4. Confirm your account by clicking the verification link sent to your email (required so ticket codes can be used with a different email if needed)
+
+Note: The Ticket Code above allows you to create an account/register for the event. It can be used with any email address and name. To sign up with a different email address than this one, or to transfer this ticket to someone else, go to ${siteUrl}/signup?ticketCode=${ticketCode} and enter the appropriate details with your ticket code.`
     const { data, error } = await resend.emails.send({
       from: 'Metagame 2025 <tickets@mail.metagame.games>',
       to,
@@ -107,23 +131,14 @@ export async function sendTicketConfirmationEmail({
       text: `
 ${adminIssued ? 'Your ticket has been issued, please complete registration' : 'Claim your ticket and complete registration'}
 
-Hi ${purchaserName},
+Hi ${purchaserName || 'there'},
 
-'Your Metagame 2025 ticket is confirmed.'} NEXT: claim your ticket and create your account so we can associate the ticket with your profile and keep you in the loop.
+Your Metagame 2025 ticket is confirmed. NEXT: claim your ticket and create your account so we can associate the ticket with your profile and keep you in the loop.
 
 Ticket Details:
-- Ticket Type: ${ticketType}
-${!adminIssued && `<p><strong>Price Paid:</strong> ${isBtc ? `₿${btcPaid?.toFixed(6)}` : `$${usdPaid?.toFixed(2)}`}</p>`}
-- Your Ticket Code: ${ticketCode} (you will need this to create your account and associate the ticket)
-${!adminIssued && isBtc ? `- OpenNode Charge ID: ${opennodeChargeId}` : `- Stripe Payment ID: ${paymentIntentId}`}
+${textTicketDetails}
 
-Next Steps:
-1. Go to ${siteUrl}/signup?email=${encodeURIComponent(to)}&ticketCode=${ticketCode}
-2. Your email and ticket code will be pre-filled
-3. Create your account and set up your profile (badge name, Discord, etc.)
-4. Confirm your account by clicking the verification link sent to your email (required so ticket codes can be used with a different email if needed)
-
-Note: The Ticket Code above allows you to create an account/register for the event. It can be used with any email address and name. To sign up with a different email address than this one, or to transfer this ticket to someone else, go to ${siteUrl}/signup?ticketCode=${ticketCode} and enter the appropriate details with your ticket code.
+${textNextSteps}
 
 Please join the Discord, where all future communication will take place: ${discordUrl}
 Housing at and near the venue can be booked via: https://www.havenbookings.space/events/metagame. Coordinate with others in the #housing Discord channel.
@@ -156,10 +171,16 @@ This is not a puzzle.
 
 /** Method so we can get notified of backend failures */
 export const sendAdminErrorEmail = async (errorMessage: string) => {
-  await resend.emails.send({
+  const { data, error } = await resend.emails.send({
     from: 'Metagame 2025 <tickets@mail.metagame.games>',
     to: ['team@metagame.games'],
     subject: '**URGENT** METAGAME Admin Error',
     html: `<p>An error occurred: ${errorMessage}</p>`,
   })
+  // Deliberately doesn't throw — callers reach for this while already handling
+  // a failure, and the alerting path shouldn't become a second failure mode.
+  if (error) {
+    console.error('Failed to send admin error email:', error, errorMessage)
+  }
+  return { success: !error, data }
 }


### PR DESCRIPTION
Bitcoin buyers were emailed the internal order UUID as their "ticket code", so signup rejected it and nobody who paid in BTC could claim their ticket — the webhook minted a real code and threw it away. Fixed alongside the plaintext half of that email (a stray `'}`, injected HTML, a literal `false` where the price goes, and `Stripe Payment ID: undefined` on admin-issued BTC tickets), plus META-424: the webhook now re-fetches the charge from OpenNode instead of acting on the unauthenticated request body.

Also in here:

- A Resend failure after the ticket row is written no longer 500s the route. OpenNode would retry, hit the idempotency guard, get a 200, and the buyer would silently never receive an email. Now it alerts admins.
- `sendAdminErrorEmail` and `sendChargeCreationEmail` never destructured `{ error }` from `resend.emails.send`, so API-level failures vanished. Both now inspect it — `sendChargeCreationEmail` throws (its caller already catches), `sendAdminErrorEmail` only logs, deliberately, so the alerting path can't become a second failure mode.
- The email labelled `dbCharge.id` (the metagame order UUID) as the "OpenNode Charge ID". It now uses the actual charge id.
- `btcPaid` is computed from `amount - missing_amt` rather than `amount`.
- The plaintext part now mirrors the HTML's `forExistingUser` branching. Previously it told existing users to go create an account while the HTML told them to reset their password, and printed a ticket code the HTML deliberately omits. Slightly beyond what META-418 enumerates — flagging it as a judgement call.

### On META-424's open question

The issue rated the analysis "likely, not certain" because the `opennode@1.5` SDK source wasn't readable. I pulled the published tarball from the npm registry and read it — `verifySignature` is `createHmac('sha256', api_key).update(charge.id).digest('hex') === charge.hashed_order`. It covers the charge id and nothing else, so `status`, `amount`, `missing_amt` and `order_id` were all attacker-controlled on a valid signature. Confirmed, not narrowed.

`updateChargeStatus` now checks the row belongs to the charge *before* the update rather than logging afterwards, so a mismatched order never gets its status flipped at all.

The dev bypass (`NODE_ENV !== 'production' && OPENNODE_ENV === 'dev'`) still falls back to the request body when `chargeInfo` fails, so local testing with synthetic webhook bodies keeps working. In production a failed re-fetch returns 502 so OpenNode retries.

## Testing required

None of this is verifiable by reading, and it's the live payment path. Someone needs to:

1. **Issue a test-mode BTC ticket end to end** and confirm the code in the confirmation email actually redeems at `/signup`. This is the core fix; everything else is secondary.
2. **Confirm a legitimate charge still processes at all.** The webhook now calls `opennode.chargeInfo(body.id)` before doing anything. If that call fails or is rate-limited in production, no ticket gets minted. Watch the logs on a real test-mode payment.
3. **Watch for a re-fetch race.** OpenNode fires the callback on the state transition; if `chargeInfo` were to lag behind and still report `processing`, we'd skip minting. I believe OpenNode persists before calling back, but a real test-mode payment is the only way to confirm.
4. **Read the raw `text/plain` part** of the confirmation email (not just the HTML) for all four shapes: webhook BTC, admin-issued BTC, admin-issued Stripe, and admin-issued for an existing user. No blank lines, no `false`, no HTML tags, no `undefined`.
5. **Check the charge-creation email still sends** — `sendChargeCreationEmail` can now throw where it previously resolved with an error payload. The caller catches and logs, so a charge should still be created either way, but confirm.

No local typecheck, lint, or build was run — there's no `node_modules` on this machine. Vercel is the gate. Formatting was verified against the repo's prettier settings.

Closes META-418, META-424.