### PR TITLE
Stop leaking attendee rosters client-side and lying about server results [META-420]

### DIFF
--- a/app/profile/hooks/useProfileUpdate.tsx
+++ b/app/profile/hooks/useProfileUpdate.tsx
@@ -24,11 +24,15 @@ export function useProfileUpdate({
     mutationFn: updateCurrentUserProfile,
     onMutate: (data) => {
       const oldData = queryClient.getQueryData<DbFullProfile>(profileQueryKey)
-      const newData = {
-        ...oldData,
-        ...data.data,
+      // Only write optimistically when there's something to roll back to — a
+      // cold cache would otherwise be seeded with a partial profile that the
+      // error path (gated on `oldData`) never reverts
+      if (oldData) {
+        queryClient.setQueryData(profileQueryKey, {
+          ...oldData,
+          ...data.data,
+        })
       }
-      queryClient.setQueryData(profileQueryKey, newData)
       return { oldData }
     },
     onSuccess: () => {

--- a/app/providers/QueryProvider.tsx
+++ b/app/providers/QueryProvider.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from 'react'
 
-import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister'
+import { PERSISTABLE_QUERY_KEYS, getQueryPersister } from './queryPersister'
 import {
   DehydratedState,
   HydrationBoundary,
@@ -39,16 +39,18 @@ export default function QueryProvider({
   // the entire app subtree right after hydration. createAsyncStoragePersister
   // documents `storage: undefined` for SSR (it returns a no-op persister), and
   // restore only runs in a client mount effect, so this is hydration-safe.
-  const [persister] = useState(() =>
-    createAsyncStoragePersister({
-      storage: typeof window === 'undefined' ? undefined : window.localStorage,
-    }),
-  )
+  const [persister] = useState(getQueryPersister)
 
   return (
     <PersistQueryClientProvider
       client={queryClient}
-      persistOptions={{ persister }}
+      persistOptions={{
+        persister,
+        dehydrateOptions: {
+          shouldDehydrateQuery: (query) =>
+            PERSISTABLE_QUERY_KEYS.includes(String(query.queryKey[0])),
+        },
+      }}
     >
       <HydrationBoundary state={state}>{children}</HydrationBoundary>
       {process.env.NODE_ENV === 'development' && (

--- a/app/providers/queryPersister.ts
+++ b/app/providers/queryPersister.ts
@@ -1,0 +1,19 @@
+import { createAsyncStoragePersister } from '@tanstack/query-async-storage-persister'
+
+/** Query keys with nothing personal in them. Everything else — `sessions` (RSVP
+ * rosters), `users`/`profiles` (names, emails), `bookmarks` — is kept out of
+ * localStorage entirely: SSR re-dehydrates it on every load, so persisting it
+ * buys nothing and leaves the previous user's data readable at rest. */
+export const PERSISTABLE_QUERY_KEYS = ['locations', 'megagame_locations']
+
+let persister: ReturnType<typeof createAsyncStoragePersister> | undefined
+
+/** One shared persister: the provider writes the cache through it and logout has
+ * to remove the same stored client. `storage: undefined` is the documented SSR
+ * no-op. */
+export const getQueryPersister = () => {
+  persister ??= createAsyncStoragePersister({
+    storage: typeof window === 'undefined' ? undefined : window.localStorage,
+  })
+  return persister
+}

--- a/app/schedule/DeclareWinningTeamButton.tsx
+++ b/app/schedule/DeclareWinningTeamButton.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react'
 import { FaFlag, FaFlagCheckered } from 'react-icons/fa'
 
 import { authedDeclareWinningTeam } from '../actions/db/sessions'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { toast } from 'sonner'
 
 import { Button, buttonVariants } from '@/components/ui/button'
 import {
@@ -21,23 +23,41 @@ import {
 } from '@/components/ui/popover'
 
 export function DeclareWinnerButton({ sessionId }: { sessionId: string }) {
+  const queryClient = useQueryClient()
   const [confirmDialog, setConfirmDialog] = useState<{
     open: boolean
     team: 'orange' | 'purple' | null
   }>({ open: false, team: null })
+
+  // The action throws on several distinct conditions (missing session, no user,
+  // not authorized, write failure); without this every one of them looked
+  // exactly like success, as did success itself
+  const declareWinnerMutation = useMutation({
+    mutationFn: authedDeclareWinningTeam,
+    onSuccess: (_result, variables) => {
+      toast.success(
+        `${variables.winningTeam.toUpperCase()} team declared the winner`,
+      )
+      setConfirmDialog({ open: false, team: null })
+    },
+    onError: (err) => {
+      toast.error(`Failed to declare winner: ${err.message}`)
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['sessions'], exact: false })
+    },
+  })
 
   const handleTeamSelect = (team: 'orange' | 'purple') => {
     setConfirmDialog({ open: true, team })
   }
 
   const handleConfirm = () => {
-    if (confirmDialog.team) {
-      authedDeclareWinningTeam({
-        sessionId: sessionId,
-        winningTeam: confirmDialog.team,
-      })
-    }
-    setConfirmDialog({ open: false, team: null })
+    if (!confirmDialog.team) return
+    declareWinnerMutation.mutate({
+      sessionId: sessionId,
+      winningTeam: confirmDialog.team,
+    })
   }
 
   const handleCancel = () => {
@@ -79,7 +99,9 @@ export function DeclareWinnerButton({ sessionId }: { sessionId: string }) {
 
       <Dialog
         open={confirmDialog.open}
-        onOpenChange={(open) => !open && handleCancel()}
+        onOpenChange={(open) =>
+          !open && !declareWinnerMutation.isPending && handleCancel()
+        }
       >
         <DialogContent className="sm:max-w-md">
           <DialogHeader>
@@ -113,18 +135,25 @@ export function DeclareWinnerButton({ sessionId }: { sessionId: string }) {
           </div>
 
           <DialogFooter className="flex gap-2">
-            <Button variant="outline" onClick={handleCancel}>
+            <Button
+              variant="outline"
+              onClick={handleCancel}
+              disabled={declareWinnerMutation.isPending}
+            >
               Cancel
             </Button>
             <Button
               onClick={handleConfirm}
+              disabled={declareWinnerMutation.isPending}
               className={
                 confirmDialog.team === 'orange'
                   ? 'bg-orange-500 text-white hover:bg-orange-600'
                   : 'bg-purple-500 text-white hover:bg-purple-600'
               }
             >
-              Confirm {confirmDialog.team?.toUpperCase()} Wins
+              {declareWinnerMutation.isPending
+                ? 'Declaring…'
+                : `Confirm ${confirmDialog.team?.toUpperCase()} Wins`}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/app/schedule/RSVPList.tsx
+++ b/app/schedule/RSVPList.tsx
@@ -1,5 +1,6 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query'
 import { UserIcon, XIcon } from 'lucide-react'
+import Link from 'next/link'
 import { toast } from 'sonner'
 
 import { countRsvpsByTeamColor } from '@/utils/dbUtils'
@@ -28,17 +29,20 @@ export const AttendanceDisplay = ({
     ? Math.floor(session.max_capacity / 2)
     : undefined
   const goingRsvps = session.rsvps.filter((rsvp) => !rsvp.on_waitlist)
+  // Anonymous callers get `rsvps: []` from the API, so any count we rendered for
+  // them would read as a real zero. Show the advertised capacity instead.
+  const capacityRangeDisplay = () => (
+    <div>
+      {session.min_capacity && session.max_capacity
+        ? session.min_capacity === session.max_capacity
+          ? `${session.min_capacity}`
+          : `${session.min_capacity} - ${session.max_capacity}`
+        : null}
+    </div>
+  )
   const standardRsvpDisplay = () => {
     if (!userLoggedIn) {
-      return (
-        <div>
-          {session.min_capacity && session.max_capacity
-            ? session.min_capacity === session.max_capacity
-              ? `${session.min_capacity}`
-              : `${session.min_capacity} - ${session.max_capacity}`
-            : null}
-        </div>
-      )
+      return capacityRangeDisplay()
     }
 
     return (
@@ -50,6 +54,9 @@ export const AttendanceDisplay = ({
     )
   }
   const megagameRsvpDisplay = () => {
+    if (!userLoggedIn) {
+      return capacityRangeDisplay()
+    }
     // Team breakdown counts only confirmed attendees, not the waitlist
     const teamCounts = countRsvpsByTeamColor(goingRsvps)
     return (
@@ -75,12 +82,18 @@ export const AttendanceDisplay = ({
         {session.megagame ? megagameRsvpDisplay() : standardRsvpDisplay()}
       </TooltipTrigger>
       <TooltipContent className="">
-        <RSVPListModal session={session} />
+        <RSVPListModal session={session} userLoggedIn={userLoggedIn} />
       </TooltipContent>
     </Tooltip>
   )
 }
-const RSVPListModal = ({ session }: { session: DbFullSession }) => {
+const RSVPListModal = ({
+  session,
+  userLoggedIn,
+}: {
+  session: DbFullSession
+  userLoggedIn: boolean
+}) => {
   const { currentUserProfile } = useUser()
   const queryClient = useQueryClient()
   const unrsvpUserMutation = useMutation({
@@ -123,6 +136,24 @@ const RSVPListModal = ({ session }: { session: DbFullSession }) => {
       queryClient.invalidateQueries({ queryKey: ['sessions'], exact: false })
     },
   })
+  // `rsvps` is empty for anonymous visitors, so rendering the list would show a
+  // fabricated "Going (0/N)" on every session
+  if (!userLoggedIn) {
+    const capacityText = session.max_capacity
+      ? session.min_capacity && session.min_capacity !== session.max_capacity
+        ? `Capacity: ${session.min_capacity} - ${session.max_capacity}`
+        : `Capacity: ${session.max_capacity}`
+      : null
+    return (
+      <div className="flex flex-col items-start gap-1">
+        {capacityText && <span className="font-bold">{capacityText}</span>}
+        <Link className="link" href="/login">
+          Sign in to see who&apos;s going
+        </Link>
+      </div>
+    )
+  }
+
   const rsvps = session.rsvps
   const teamsToBgColors: Record<DbTeamColor, string> = {
     orange: 'text-orange-600',

--- a/app/schedule/scheduleUtils.ts
+++ b/app/schedule/scheduleUtils.ts
@@ -1,6 +1,6 @@
 import { dbGetHostsFromSession } from '@/utils/dbUtils'
 
-import { DbFullSession } from '@/types/database/dbTypeAliases'
+import { DbCalendarSession } from '@/types/database/dbTypeAliases'
 
 export const sessionCalendarDateString = (date: Date) => {
   const year = date.getUTCFullYear().toString().padStart(4, '0')
@@ -11,7 +11,7 @@ export const sessionCalendarDateString = (date: Date) => {
   const seconds = date.getUTCSeconds().toString().padStart(2, '0')
   return `${year}${month}${day}T${hours}${minutes}${seconds}Z`
 }
-export const sessionCalendarDescription = (session: DbFullSession) => {
+export const sessionCalendarDescription = (session: DbCalendarSession) => {
   const locationString = session.location?.name
     ? `Location: ${session.location.name}`
     : ''
@@ -19,7 +19,7 @@ export const sessionCalendarDescription = (session: DbFullSession) => {
   const detailsString = `${locationString}\nHosts: ${hostsString}\n\n=================\n\n${session.description + '\n\n=================\n\n' || ''}<a href=${sessionLink(session.id)}>${sessionLink(session.id)}</a>`
   return detailsString
 }
-export const gCalLinkFromSession = (session: DbFullSession) => {
+export const gCalLinkFromSession = (session: DbCalendarSession) => {
   const addressString = '2740 Telegraph Ave, Berkeley, CA 94705'
   const title = `Metagame: ${session.title || 'Untitled Session'}`
   const detailsString = sessionCalendarDescription(session)

--- a/components/AddToCalendar.tsx
+++ b/components/AddToCalendar.tsx
@@ -12,9 +12,9 @@ import {
 
 import { gCalLinkFromSession } from '@/app/schedule/scheduleUtils'
 
-import { DbFullSession } from '@/types/database/dbTypeAliases'
+import { DbCalendarSession } from '@/types/database/dbTypeAliases'
 
-export function AddToCalendar({ session }: { session: DbFullSession }) {
+export function AddToCalendar({ session }: { session: DbCalendarSession }) {
   return (
     <Popover>
       <PopoverTrigger

--- a/components/sections/home/Highlights.tsx
+++ b/components/sections/home/Highlights.tsx
@@ -3,6 +3,8 @@ import Link from 'next/link'
 
 import { sessionsService } from '@/lib/db/sessions'
 
+import { sessionCalendarFields } from '@/utils/dbUtils'
+
 import AddToCalendar from '@/components/AddToCalendar'
 import { Separator } from '@/components/ui/separator'
 
@@ -50,7 +52,9 @@ export default async function Highlights() {
             <div className="flex gap-4">
               <span className="text-lg">7-10 PM Friday night</span>
               {nightMarketSession && (
-                <AddToCalendar session={nightMarketSession} />
+                <AddToCalendar
+                  session={sessionCalendarFields(nightMarketSession)}
+                />
               )}
             </div>
           </div>

--- a/hooks/schedule/useScheduleStuff.tsx
+++ b/hooks/schedule/useScheduleStuff.tsx
@@ -172,19 +172,11 @@ export function useScheduleStuff() {
         return { previousSessions, aborted: true as const }
       }
 
-      // Optimistically add RSVP (simplified - no waitlist logic)
-      // Determine optimistic waitlist based on megagame team caps
       const sessions = queryClient.getQueryData<DbFullSession[]>(['sessions'])
       const session = sessions?.find((s) => s.id === sessionId)
-      const userTeam = currentUserProfile?.team || 'unassigned'
-      let optimisticWaitlist = false
-      if (session?.megagame && session.max_capacity) {
-        const teamCap = Math.floor(session.max_capacity / 2)
-        const currentTeamGoing = (session.rsvps || []).filter(
-          (r) => r.user.team === userTeam && !r.on_waitlist,
-        ).length
-        optimisticWaitlist = currentTeamGoing >= teamCap
-      }
+      // Full regular sessions waitlist you too, so ask the same predicate the
+      // RSVP button uses rather than optimistically claiming a spot
+      const optimisticWaitlist = isSessionFull(sessionId)
 
       const newRsvp: DbFullSessionRsvp = {
         session_id: sessionId,
@@ -271,7 +263,7 @@ export function useScheduleStuff() {
       await queryClient.cancelQueries({
         queryKey: ['bookmarks', 'current'],
       })
-      const previousBookmarks = queryClient.getQueryData([
+      const previousBookmarks = queryClient.getQueryData<DbSessionBookmark[]>([
         'bookmarks',
         'current',
       ])
@@ -302,7 +294,14 @@ export function useScheduleStuff() {
         toast.success('Bookmarked')
       }
     },
-    onError: (err) => {
+    onError: (err, _variables, context) => {
+      // Rollback on error
+      if (context?.previousBookmarks) {
+        queryClient.setQueryData<DbSessionBookmark[]>(
+          ['bookmarks', 'current'],
+          context.previousBookmarks,
+        )
+      }
       toast.error(err.message)
     },
     onSettled: () => {

--- a/hooks/useLogout.ts
+++ b/hooks/useLogout.ts
@@ -6,6 +6,7 @@ import { useQueryClient } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
 
 import { logout } from '@/app/actions/auth/logout'
+import { getQueryPersister } from '@/app/providers/queryPersister'
 
 export function useLogout() {
   const queryClient = useQueryClient()
@@ -16,20 +17,18 @@ export function useLogout() {
     try {
       setIsLoggingOut(true)
 
-      // Clear all user-related queries immediately
-      queryClient.removeQueries({ queryKey: ['users'] })
-
       // Call server action to logout
       await logout(redirectTo)
-
-      // After logout, invalidate all queries to ensure fresh data
-      await queryClient.invalidateQueries()
     } catch (error) {
       console.error('Logout failed:', error)
-      // If logout fails, still clear cache and redirect
-      queryClient.clear()
       router.push(redirectTo)
     } finally {
+      // Drop the cache whether or not the server call succeeded. `clear()` and
+      // `removeClient()` both matter: invalidateQueries only marks queries
+      // stale, and the persisted copy in localStorage outlives the tab.
+      queryClient.clear()
+      await getQueryPersister().removeClient()
+
       // Reset the logging out state after a small delay to ensure UI updates
       setTimeout(() => setIsLoggingOut(false), 100)
     }

--- a/types/database/dbTypeAliases.ts
+++ b/types/database/dbTypeAliases.ts
@@ -22,6 +22,21 @@ export type DbFullSession = Tables<'sessions'> & {
   megagame_location: Pick<DbMegagameLocation, 'id' | 'name'> | null
 }
 
+/** The session fields the calendar links read — notably no `rsvps`/`bookmarks`.
+ * Server components must narrow to this before handing a session to a client
+ * component, or React serializes the attendee roster into the public HTML. */
+export type DbCalendarSession = Pick<
+  DbFullSession,
+  | 'id'
+  | 'title'
+  | 'description'
+  | 'start_time'
+  | 'end_time'
+  | 'host_1'
+  | 'host_2'
+  | 'host_3'
+> & { location: Pick<DbLocation, 'name'> | null }
+
 export type DbSessionCategory = Enums<'SESSION_CATEGORY'>
 export type DbSessionAges = Enums<'AGES'>
 export type DbTicketType = Enums<'ticket_type'>

--- a/utils/dbUtils.ts
+++ b/utils/dbUtils.ts
@@ -1,4 +1,5 @@
 import {
+  DbCalendarSession,
   DbFullSession,
   DbFullSessionRsvp,
   DbSessionAges,
@@ -7,7 +8,9 @@ import {
   DbTicketType,
 } from '@/types/database/dbTypeAliases'
 
-export const dbGetHostsFromSession = (session: DbFullSession) => {
+export const dbGetHostsFromSession = (
+  session: Pick<DbFullSession, 'host_1' | 'host_2' | 'host_3'>,
+) => {
   const host1Name = !session.host_1?.first_name
     ? ''
     : (session.host_1.first_name ?? '') + ' ' + (session.host_1.last_name ?? '')
@@ -81,6 +84,22 @@ export const sessionWithoutAttendees = (
   ...session,
   rsvps: [],
   bookmarks: [],
+})
+
+/** Narrow a session down to what the calendar links need, so a server component
+ * can render <AddToCalendar> without serializing the roster into the HTML. */
+export const sessionCalendarFields = (
+  session: DbFullSession,
+): DbCalendarSession => ({
+  id: session.id,
+  title: session.title,
+  description: session.description,
+  start_time: session.start_time,
+  end_time: session.end_time,
+  host_1: session.host_1,
+  host_2: session.host_2,
+  host_3: session.host_3,
+  location: session.location && { name: session.location.name },
 })
 
 export const countRsvpsByTeamColor = (


### PR DESCRIPTION
Four client-side fixes: two paths that hand attendee data to people who shouldn't have it (homepage RSC payload, localStorage), and two classes of UI that report success the server never gave. Covers META-420, META-425, META-430, META-431.

- **META-420** — `<AddToCalendar>` is a client component, so a whole `DbFullSession` prop gets serialized into anonymous HTML, roster included. Added `DbCalendarSession` (id/title/description/times/hosts/location name) and a `sessionCalendarFields()` narrowing helper; the homepage passes that instead. `SessionModalCard` is already a client component so its call site is unchanged.
- **META-425** — Added a `dehydrateOptions.shouldDehydrateQuery` allowlist so only `locations`/`megagame_locations` ever reach localStorage, and `useLogout` now does `queryClient.clear()` + `persister.removeClient()` (the persister moved to a shared `app/providers/queryPersister.ts` so logout can reach it).
- **META-430** — `userLoggedIn` is threaded into `RSVPListModal`, which now shows capacity + "Sign in to see who's going" instead of `Going (0/24)`; `megagameRsvpDisplay()` picked up the same check its standard sibling already had.
- **META-431** — Optimistic RSVP calls the existing `isSessionFull` predicate instead of hardcoding `on_waitlist: false`; the bookmark mutation rolls back `previousBookmarks` on error; declare-winner is a real mutation with error toast, pending state, and a `['sessions']` invalidate; `useProfileUpdate` only writes optimistically when there's an `oldData` to roll back to.

## Testing required

None of this is evaluable by reading a diff — it's all visual and stateful, and I could not run a browser or a build.

1. **Homepage leak** — `curl -s <preview-url> | grep -c '"first_name"'` with no cookie should be `0`. Then log in and confirm the Night Market "Add to calendar" popover still produces a working Google Calendar link and ICS download (the gcal link is built from the narrowed fields now, so check title/time/location/hosts/description all still appear).
2. **Schedule logged out** — open `/schedule` signed out and tap the attendee icon on **both** a standard session and a megagame session. Expect capacity text + a sign-in link, never `Going (0/N)` and never an empty list. Sign in and confirm the real rosters and per-team counts come back.
3. **Full-session RSVP** — RSVP to a session that is already at `max_capacity`. It should say waitlisted **immediately**, not flip from "you're in" to "Added to waitlist" a moment later. Re-check a megagame session at team cap too, since that branch was rewritten to share the same predicate.
4. **Logout hygiene** — log in, browse the schedule, then log out and inspect `localStorage` in devtools. The `REACT_QUERY_OFFLINE_CACHE` key should be gone, and while logged in it should never contain `first_name`/`email`. Sanity-check that a reload after logout still renders the schedule normally (it comes from SSR, not the persisted cache).
5. **Declare winner** — as a host/GREEN, declare a winner and confirm a success toast plus the flag updating. Then trigger a failure (e.g. as a non-authorized user) and confirm an error toast with the dialog staying open, rather than silently closing.
6. **Profile update** — save the profile form on a cold cache (hard reload straight onto `/profile`, then save) and confirm the values persist correctly.

Note: no local typecheck, lint, build, or prettier was run (no `node_modules` on this box) — CI is the gate.