### PR TITLE
Gate card redemption on the winning team [META-419]

### DIFF
--- a/app/actions/db/users.ts
+++ b/app/actions/db/users.ts
@@ -104,7 +104,6 @@ export const currentUserSelectCardReward = currentUserWrapper(
     celestialCardId: number
     sessionId: string
   }) => {
-    // look up which team won session and check that user is on that team and rsvpd to that session
     const session = await sessionsService.getSessionById({ sessionId })
     if (!session) {
       throw new Error('Session not found. Please refresh and try again.')
@@ -132,10 +131,22 @@ export const currentUserSelectCardReward = currentUserWrapper(
         'You have already claimed a card reward for this session.',
       )
     }
-    const cardRewards = session.card_rewards
-    // verify that the card is in the list of allowed card rewards or the user is keeping their current celestial card
+    // The set of rewards depends on the team: winners choose from all of the
+    // session's cards; losers only from the one flagged `loser_option` (mirrors
+    // the restriction CardPicker applies in the UI). Either team may instead
+    // keep the card they already have.
+    const isWinner = userProfile.team === winningTeam
+    const loserOption =
+      session.card_rewards.find((card) =>
+        card.details.some((detail) => detail.loser_option),
+      ) ?? session.card_rewards[0]
+    const availableCards = isWinner
+      ? session.card_rewards
+      : loserOption
+        ? [loserOption]
+        : []
     if (
-      !cardRewards.map((card) => card.id).includes(celestialCardId) &&
+      !availableCards.some((card) => card.id === celestialCardId) &&
       !(celestialCardId == userProfile.celestial_card_id)
     ) {
       throw new Error(


### PR DESCRIPTION
The card-redemption server action (`currentUserSelectCardReward`) never checked the caller's team, so a losing player calling it directly could take any winner-only card instead of the loser option the UI restricts them to. Build the allowed reward set by team, mirroring `CardPicker`: winners choose from all `session.card_rewards`, losers only the one flagged `loser_option` (with the same `?? card_rewards[0]` fallback). Either team may still keep their current card.

Everyone still gets a claim on `declareWinningTeam` — winners and losers both get rewarded, losers just get fewer choices. This PR is only the redemption-side team check.

First of a stack splitting the old #305:
- **this** → team check (META-419)
- `meta-b-keep-current` → drop the 9999 magic id
- `meta-c-claim-window` → server-owned claim window
- `meta-d-card-atomicity` → declare/claim CAS (META-429)
- `meta-e-ticket-race` → ticket claim CAS (META-429)

## Already verified
Nothing — no `node_modules` on this machine, so no local typecheck/lint. Vercel is the gate.

## Test plan
- Declare a winner on a test session with attendees on both teams.
- As a losing player, call `currentUserSelectCardReward` directly with a winner-only card id → rejected.
- Same losing player can take the `loser_option` card and can keep their current card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)