### PR TITLE
Make the card-claim window a server-owned constant [META-419]

### DIFF
--- a/app/actions/db/users.ts
+++ b/app/actions/db/users.ts
@@ -6,7 +6,10 @@ import {
   currentUserWrapper,
 } from './auth'
 
-import { playerCardClaimsService } from '@/lib/db/playerCardClaims'
+import {
+  CARD_CLAIM_WINDOW_MS,
+  playerCardClaimsService,
+} from '@/lib/db/playerCardClaims'
 import { sessionsService } from '@/lib/db/sessions'
 import { usersService } from '@/lib/db/users'
 import {
@@ -131,6 +134,10 @@ export const currentUserSelectCardReward = currentUserWrapper(
         'You have already claimed a card reward for this session.',
       )
     }
+    const claimAge = Date.now() - new Date(userCardClaim.created_at).getTime()
+    if (claimAge > CARD_CLAIM_WINDOW_MS) {
+      throw new Error('The window to claim this card reward has closed.')
+    }
     // The set of rewards depends on the team: winners choose from all of the
     // session's cards; losers only from the one flagged `loser_option` (mirrors
     // the restriction CardPicker applies in the UI). Either team may instead
@@ -161,11 +168,7 @@ export const currentUserSelectCardReward = currentUserWrapper(
   },
 )
 
-export const currentUserLatestUnclaimedVictory = async ({
-  timeWindow,
-}: {
-  timeWindow: number
-}) => {
+export const currentUserLatestUnclaimedVictory = async () => {
   const user = await usersService.getCurrentUser()
   if (!user) {
     return null
@@ -173,7 +176,7 @@ export const currentUserLatestUnclaimedVictory = async ({
   const playerCardClaims =
     await playerCardClaimsService.getOpenPlayerCardClaimsByPlayerId({
       userId: user.id,
-      timeWindow,
+      timeWindow: CARD_CLAIM_WINDOW_MS,
     })
   if (playerCardClaims.length === 0) {
     return null

--- a/components/PickACard/PickACardMetaProvider.tsx
+++ b/components/PickACard/PickACardMetaProvider.tsx
@@ -3,9 +3,7 @@ import PickACard from './PickACardProvider'
 import { currentUserLatestUnclaimedVictory } from '@/app/actions/db/users'
 
 export default async function PickACardMetaProvider() {
-  const unclaimedVictory = await currentUserLatestUnclaimedVictory({
-    timeWindow: 1000 * 60 * 60 * 24 * 5,
-  })
+  const unclaimedVictory = await currentUserLatestUnclaimedVictory()
   if (!unclaimedVictory) {
     return null
   }

--- a/lib/db/playerCardClaims.ts
+++ b/lib/db/playerCardClaims.ts
@@ -1,5 +1,9 @@
 import { createServiceClient } from '@/utils/supabase/service'
 
+/** How long after a win a player has to redeem their card reward. Server-owned:
+ * it used to arrive as a caller-supplied argument. */
+export const CARD_CLAIM_WINDOW_MS = 1000 * 60 * 60 * 24 * 5
+
 export const playerCardClaimsService = {
   getPlayerCardClaims: async ({ userId }: { userId: string }) => {
     const supabase = createServiceClient()


### PR DESCRIPTION
The 5-day redemption window was passed in as a caller-supplied argument to `currentUserLatestUnclaimedVictory`, and the redemption action never enforced it at all. Move it to `CARD_CLAIM_WINDOW_MS` in the claims service and check the claim's `created_at` against it on redemption.

Stacked on `meta-b-keep-current`. Part of splitting #305.

## Already verified
Nothing — no local build possible on this machine. Vercel is the gate.

## Test plan
- Redeem a fresh claim → succeeds.
- A claim older than 5 days → rejected with "The window to claim this card reward has closed."

🤖 Generated with [Claude Code](https://claude.com/claude-code)