### PR TITLE
Make megagame reward declare + claim atomic [META-429]

### DIFF
--- a/app/actions/db/sessions.ts
+++ b/app/actions/db/sessions.ts
@@ -45,12 +45,18 @@ export const authedDeclareWinningTeam = async ({
   if (!authed) {
     throw new Error('You are not authorized to declare the winning team')
   }
-  const winnerUserIds = session.rsvps
+  const declaredSession = await sessionsService.declareWinningTeam({
+    sessionId,
+    winningTeam,
+  })
+  if (!declaredSession) {
+    throw new Error('A winning team has already been declared for this session')
+  }
+  const attendeeUserIds = session.rsvps
     .filter((rsvp) => !rsvp.on_waitlist)
     .map((rsvp) => rsvp.user_id)
-  await sessionsService.declareWinningTeam({ sessionId, winningTeam })
   await playerCardClaimsService.createOpenPlayerCardClaims({
-    userIds: winnerUserIds,
+    userIds: attendeeUserIds,
     sessionId,
   })
 }

--- a/app/actions/db/users.ts
+++ b/app/actions/db/users.ts
@@ -160,11 +160,17 @@ export const currentUserSelectCardReward = currentUserWrapper(
         'The selected card is not available as a reward for this session.',
       )
     }
-    return playerCardClaimsService.makePlayerCardClaim({
+    const claim = await playerCardClaimsService.makePlayerCardClaim({
       userId,
       sessionId,
       newCardId: celestialCardId,
     })
+    if (!claim) {
+      throw new Error(
+        'You have already claimed a card reward for this session.',
+      )
+    }
+    return claim
   },
 )
 

--- a/lib/db/playerCardClaims.ts
+++ b/lib/db/playerCardClaims.ts
@@ -30,6 +30,11 @@ export const playerCardClaimsService = {
       .select('*')
       .eq('user_id', userId)
       .eq('session_id', sessionId)
+      /* Tolerate duplicate rows: nothing enforces uniqueness on
+       * (user_id, session_id), and a bare .maybeSingle() errors on more than
+       * one row, locking every attendee of that session out of claiming. */
+      .order('created_at', { ascending: false })
+      .limit(1)
       .maybeSingle()
     if (error) {
       throw new Error(error.message)
@@ -110,7 +115,8 @@ export const playerCardClaimsService = {
     }
     return data
   },
-  /** Does NOT do the validation of card choice */
+  /** Does NOT do the validation of card choice. Returns null if the claim was
+   * already redeemed (e.g. a second browser tab got there first). */
   makePlayerCardClaim: async ({
     userId,
     sessionId,
@@ -121,15 +127,20 @@ export const playerCardClaimsService = {
     newCardId: number
   }) => {
     const supabase = createServiceClient()
-    const { data, error } = await supabase
+    // Compare-and-swap: whoever flips new_card_id off null owns the reward
+    const { data: claims, error } = await supabase
       .from('player_card_claims')
       .update({ new_card_id: newCardId })
       .eq('user_id', userId)
       .eq('session_id', sessionId)
+      .is('new_card_id', null)
       .select()
-      .single()
     if (error) {
       throw new Error(error.message)
+    }
+    const playerCardClaim = claims[0]
+    if (!playerCardClaim) {
+      return null
     }
     const { data: updatedProfile, error: updateError } = await supabase
       .from('profiles')
@@ -138,10 +149,18 @@ export const playerCardClaimsService = {
       .select()
       .single()
     if (updateError) {
+      /* Reopen the claim: otherwise the reward is spent but the card never
+       * landed, and new_card_id being set blocks any retry. */
+      await supabase
+        .from('player_card_claims')
+        .update({ new_card_id: null })
+        .eq('user_id', userId)
+        .eq('session_id', sessionId)
+        .eq('new_card_id', newCardId)
       throw new Error(updateError.message)
     }
     return {
-      playerCardClaim: data,
+      playerCardClaim,
       updatedProfile,
     }
   },

--- a/lib/db/sessions.ts
+++ b/lib/db/sessions.ts
@@ -173,7 +173,7 @@ export const sessionsService = {
 
     const { data: session, error } = await supabase
       .from('sessions')
-      .select('megagame, winning_team, megagame_location')
+      .select('megagame, megagame_location')
       .eq('id', sessionId)
       .single()
     if (error) {
@@ -182,10 +182,27 @@ export const sessionsService = {
     if (!session.megagame) {
       throw new Error('Session is not a megagame')
     }
-    if (session.winning_team) {
-      throw new Error('Winning team already declared')
+
+    /* Compare-and-swap on winning_team: a read-then-write guard lets two hosts
+     * (or one double-tap) both declare and mint duplicate card claims. */
+    const { data, error: updateError } = await supabase
+      .from('sessions')
+      .update({
+        winning_team: winningTeam,
+        win_timestamp: new Date().toISOString(),
+      })
+      .eq('id', sessionId)
+      .is('winning_team', null)
+      .select()
+      .maybeSingle()
+    if (updateError) {
+      throw new Error(updateError.message)
+    }
+    if (!data) {
+      return null
     }
 
+    // Only once the session row is ours, so the map can't contradict it
     if (session.megagame_location) {
       const { error: locationError } = await supabase
         .from('megagame_locations')
@@ -198,18 +215,6 @@ export const sessionsService = {
       }
     }
 
-    const { data, error: updateError } = await supabase
-      .from('sessions')
-      .update({
-        winning_team: winningTeam,
-        win_timestamp: new Date().toISOString(),
-      })
-      .eq('id', sessionId)
-      .select()
-      .single()
-    if (updateError) {
-      throw new Error(updateError.message)
-    }
     return data
   },
   /** Get a list of sessions whose victory timesamps are within the specified timewindow */


### PR DESCRIPTION
Three read-then-write races in the megagame reward path become compare-and-swaps:

- `declareWinningTeam` CASes `winning_team` off null, so a double-tapped "Declare winner" (two tabs / flaky wifi) can't mint two rounds of card claims; the second call throws "already been declared". The `megagame_locations.control` write moves *after* the CAS so the map can never contradict the session.
- `makePlayerCardClaim` CASes `new_card_id` off null; a second tab picking a different card gets "already claimed" instead of silently overwriting the first.
- If the profile write fails after the claim is consumed, the claim is reopened so the user can retry.
- `getPlayerCardClaimsByUserIdAndSessionId` now orders + `limit(1)`s, so any duplicate rows already in prod degrade to "newest wins" instead of erroring `maybeSingle()` and bricking claims for the whole session.

Stacked on `meta-c-claim-window`. Part of splitting #305. Covers the card-side races in META-429.

## Follow-up: unique constraint on `player_card_claims`
That table was created via the Supabase dashboard with no migration in the repo, so whether `(user_id, session_id)` is unique can't be determined from the codebase (no DB access here). This PR deliberately does **not** add an `upsert ... onConflict`, which would fail at runtime if the constraint is missing. The CAS prevents duplicate claim rows at the source either way, and the `limit(1)` read degrades gracefully. Confirming wants `\d player_card_claims` against prod.

## Already verified
Nothing — no local build possible on this machine. Vercel is the gate.

## Test plan
- Double-tap "Declare winner" in two tabs → exactly one round of claims; second call errors.
- Double-tap the card picker in two tabs with different cards → one wins, the other gets "already claimed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)