### PR TITLE
Make ticket claiming atomic and clean up the orphaned signup [META-429]

### DIFF
--- a/app/actions/db/tickets.ts
+++ b/app/actions/db/tickets.ts
@@ -73,7 +73,25 @@ export const signupByTicketCode = async ({
     }
     userId = user.id
   }
-  await ticketsService.updateTicketOwner({ ticketCode, ownerId: userId })
+  const claimedTicket = await ticketsService.updateTicketOwner({
+    ticketCode,
+    ownerId: userId,
+  })
+  if (!claimedTicket) {
+    if (!existingUser) {
+      /* We only signed this account up to hold the ticket, so losing the race
+       * would otherwise strand an account with no ticket behind it. */
+      try {
+        await usersService.fullDeleteUser({ userId })
+      } catch (cleanupError) {
+        console.error(
+          'Failed to remove signup after a lost ticket claim',
+          cleanupError,
+        )
+      }
+    }
+    return { success: false, error: 'claimed', ticket: null }
+  }
   // Teams are assigned once. Claiming another ticket must not reroll the team of
   // someone who already has one.
   const profile =
@@ -88,7 +106,7 @@ export const signupByTicketCode = async ({
       },
     })
   }
-  return { success: true, error: null, ticket: ticket }
+  return { success: true, error: null, ticket: claimedTicket }
 }
 export const volunteerGetAllFullTickets = async () => {
   await assertAuthLevel({ authLevel: 'VOLUNTEER' })

--- a/lib/db/tickets.ts
+++ b/lib/db/tickets.ts
@@ -123,6 +123,9 @@ export const ticketsService = {
     }
     return data
   },
+  /** Claims an unowned ticket. Returns null if someone else already owns it: a
+   * forwarded code can be redeemed by two people at once, and without the
+   * compare-and-swap the last writer wins and both are told they succeeded. */
   updateTicketOwner: async ({
     ticketCode,
     ownerId,
@@ -135,8 +138,9 @@ export const ticketsService = {
       .from('tickets')
       .update({ owner_id: ownerId })
       .eq('ticket_code', ticketCode)
+      .is('owner_id', null)
       .select()
-      .single()
+      .maybeSingle()
     if (error) {
       throw new Error(error.message)
     }


### PR DESCRIPTION
`updateTicketOwner` CASes `owner_id` off null, so a forwarded ticket code redeemed from two browsers at once resolves to exactly one winner instead of last-writer-wins telling both they succeeded. When the CAS loses and we'd just created an auth account solely to hold the ticket, that account is deleted rather than left stranded with a profile, a team, and no ticket (which surfaces at check-in as an unclaimed-ticket no-show).

Independent of the card-reward stack — branches off `main`. Covers the ticket-side race in META-429.

## Already verified
Nothing — no local build possible on this machine. Vercel is the gate.

## Test plan
- Claim one forwarded ticket code from two browsers at once → exactly one succeeds; the loser sees the `claimed` error and leaves no orphaned auth user behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)